### PR TITLE
Improved MainWindowWithDetachableDockWidgets::updateDocksAndTabs.

### DIFF
--- a/src/ui/veles_mainwindow.cc
+++ b/src/ui/veles_mainwindow.cc
@@ -930,6 +930,7 @@ void MainWindowWithDetachableDockWidgets::updateCloseButtonsOnTabBars() {
 void MainWindowWithDetachableDockWidgets::updateDocksAndTabs() {
   updateCloseButtonsOnTabBars();
   updateDockWidgetTitleBars();
+  layout()->invalidate();
 }
 
 bool MainWindowWithDetachableDockWidgets::event(QEvent* event) {


### PR DESCRIPTION
Explicitly calling QLayout::update in MainWindowWithDetachableDockWidgets::updateDocksAndTabs. It should prevent undesired behavior related to top level windows not refreshing accordingly.