### PR TITLE
Wip/maciek/minimap bugfixes

### DIFF
--- a/include/util/sampling/isampler.h
+++ b/include/util/sampling/isampler.h
@@ -116,9 +116,10 @@ class ISampler {
    * the semantic of what is actually returned is not very clearly defined.
    * However it should be the location in file that somehow corresponds to
    * the given byte.
-   * There are two specific indexes with guaranteed values:
+   * There are three specific indexes with guaranteed values:
    * - getFileOffset(0) is always first address in underlying data,
    * - getFileOffset(getSampleSize() - 1) the last address.
+   * - getFileOffset(getSampleSize()) the last address + 1.
    */
   size_t getFileOffset(size_t index);
 

--- a/include/visualisation/minimap.h
+++ b/include/visualisation/minimap.h
@@ -116,6 +116,8 @@ class VisualisationMinimap : public QOpenGLWidget,
   static float* calculateEntropyTextureSingleWindow(
       const uint8_t *sample, size_t sample_size,
       size_t texture_size, double point_size);
+  static float calculateEntropyValue(uint64_t bytes_counts[],
+                                     uint64_t total_count);
 
   bool empty();
 

--- a/src/util/sampling/isampler.cc
+++ b/src/util/sampling/isampler.cc
@@ -75,9 +75,10 @@ size_t ISampler::getFileOffset(size_t index) {
   assert(!empty());
   auto lc = lock();
   size_t sample_s = getRequestedSampleSize();
-  assert(index < sample_s);
+  assert(index <= sample_s);
   if (index == 0) return start_;
   if (index == sample_s - 1) return end_ - 1;
+  if (index == sample_s) return end_;
   if (!samplingRequired()) {
     return index + start_;
   }

--- a/src/visualisation/minimap.cc
+++ b/src/visualisation/minimap.cc
@@ -57,7 +57,9 @@ QPair<size_t, size_t> VisualisationMinimap::getSelectedRange() {
 
 void VisualisationMinimap::setSelectedRange(size_t start_address, size_t end_address) {
   selection_start_ = sampler_->getSampleOffset(start_address);
-  selection_end_ = sampler_->getSampleOffset(end_address - 1);
+  selection_end_ = (end_address == sampler_->getRange().second) ?
+                    sampler_->getSampleSize() :
+                    sampler_->getSampleOffset(end_address - 1);
   if (gl_initialised_) {
     top_line_pos_ = normaliseLinePosition(offsetToLine(selection_start_));
     bottom_line_pos_ = normaliseLinePosition(offsetToLine(selection_end_));

--- a/src/visualisation/minimap.cc
+++ b/src/visualisation/minimap.cc
@@ -43,7 +43,7 @@ VisualisationMinimap::~VisualisationMinimap() {
 void VisualisationMinimap::setSampler(util::ISampler *sampler) {
   sampler_ = sampler;
   selection_start_ = 0;
-  selection_end_ = (empty()) ? 0 : sampler_->getSampleSize() - 1;
+  selection_end_ = (empty()) ? 0 : sampler_->getSampleSize();
   initialised_ = true;
   refresh();
 }

--- a/src/visualisation/minimap.cc
+++ b/src/visualisation/minimap.cc
@@ -650,8 +650,8 @@ float VisualisationMinimap::normaliseLinePosition(float line) {
 size_t VisualisationMinimap::lineToOffset(float line_position) {
   assert(line_position >= -1.0);
   assert(line_position <= 1.0);
-  float row_size = 2.0 / texture_rows_;
-  float line_row = (line_position + 1) / row_size;
+  double row_size = 2.0 / texture_rows_;
+  double line_row = (line_position + 1) / row_size;
   if (line_row > texture_rows_) {
     return 0;
   }
@@ -659,14 +659,15 @@ size_t VisualisationMinimap::lineToOffset(float line_position) {
   if (row == texture_rows_) {
     return sample_size_;
   }
-  size_t row_bytes = point_size_ * texture_cols_;
-  return std::min(sample_size_, row_bytes * row);
+  double row_bytes = point_size_ * texture_cols_;
+  return std::min(sample_size_, static_cast<size_t>(row_bytes * row));
 }
 
 float VisualisationMinimap::offsetToLine(size_t offset) {
-  float row_size = 2.0 / texture_rows_;
-  size_t row_bytes = point_size_ * texture_cols_;
-  float position = -1.0 * (((offset / row_bytes) * row_size) - 1);
+  double row_size = 2.0 / texture_rows_;
+  double row_bytes = point_size_ * texture_cols_;
+  float position = static_cast<float>(
+      -1.0 * (((offset / row_bytes) * row_size) - 1));
   return std::min(1.0f, std::max(-1.0f, position));
 }
 

--- a/src/visualisation/minimap.cc
+++ b/src/visualisation/minimap.cc
@@ -651,12 +651,16 @@ size_t VisualisationMinimap::lineToOffset(float line_position) {
   assert(line_position >= -1.0);
   assert(line_position <= 1.0);
   float row_size = 2.0 / texture_rows_;
-  size_t row = texture_rows_ - ((line_position + 1) / row_size);
+  float line_row = (line_position + 1) / row_size;
+  if (line_row > texture_rows_) {
+    return 0;
+  }
+  size_t row = texture_rows_ - line_row;
   if (row == texture_rows_) {
-    return sample_size_ - 1;
+    return sample_size_;
   }
   size_t row_bytes = point_size_ * texture_cols_;
-  return std::min(sample_size_ - 1, row_bytes * row);
+  return std::min(sample_size_, row_bytes * row);
 }
 
 float VisualisationMinimap::offsetToLine(size_t offset) {

--- a/src/visualisation/minimap.cc
+++ b/src/visualisation/minimap.cc
@@ -20,7 +20,6 @@
 #include <cmath>
 #include <assert.h>
 
-
 namespace veles {
 namespace visualisation {
 
@@ -123,17 +122,19 @@ float* VisualisationMinimap::calculateAverageValueTexture(
 
   size_t index = 0;
   for (size_t i = 0; i < sample_size; ++i) {
-    point_sum += sample[i];
-    point_count += 1;
-    if (static_cast<double>(i) / point_size >= index + 1) {
-      if (index == texture_size - 1 && i < sample_size - 1) continue;
+    if (index < texture_size - 1 &&
+        static_cast<double>(i) / point_size >= index + 1) {
       uint8_t result = (point_count == 0) ? 0 : point_sum / point_count;
       bigtab[index] = static_cast<float>(result); // HAX
       index += 1;
       point_sum = 0;
       point_count = 0;
     }
+    point_sum += sample[i];
+    point_count += 1;
   }
+  bigtab[texture_size - 1] = static_cast<float>(
+      (point_count == 0) ? 0 : point_sum / point_count);
   return bigtab;
 }
 
@@ -316,10 +317,12 @@ void VisualisationMinimap::initTextures() {
   if (sample_size_ < texture_size) {
     float scale_factor = std::sqrt(static_cast<float>(sample_size_) /
                                    static_cast<float>(texture_size));
-    texture_rows_ = std::max(static_cast<size_t>(1),
-                             static_cast<size_t>(rows_ * scale_factor));
-    texture_cols_ = std::max(static_cast<size_t>(1),
-                             static_cast<size_t>(cols_ * scale_factor));
+    texture_cols_ = static_cast<size_t>(
+        std::max(1.0f, cols_ * scale_factor));
+    texture_rows_ = static_cast<size_t>(
+        std::max(1.0f,
+            std::min(static_cast<float>(sample_size_) / texture_cols_,
+                     rows_ * scale_factor)));
     texture_size = texture_rows_ * texture_cols_;
   }
 

--- a/src/visualisation/minimap_panel.cc
+++ b/src/visualisation/minimap_panel.cc
@@ -193,7 +193,7 @@ void MinimapPanel::showSelectRangeDialog() {
   if (select_range_dialog_->isVisible()) return;
   if (sampler_->empty()) return;
   auto min_address = sampler_->getFileOffset(0);
-  auto max_address = sampler_->getFileOffset(sampler_->getSampleSize() - 1);
+  auto max_address = sampler_->getFileOffset(sampler_->getSampleSize());
   select_range_dialog_->resetNumberFormat();
   select_range_dialog_->setRange(min_address, max_address);
   select_range_dialog_->show();
@@ -205,7 +205,7 @@ void MinimapPanel::selectRange() {
   size_t center = start + ((end - start) / 2);
   size_t size = end - start;
   size_t curr_start = 0;
-  size_t curr_end = sampler_->getFileOffset(sampler_->getSampleSize() - 1);
+  size_t curr_end = sampler_->getFileOffset(sampler_->getSampleSize());
   int index = 0;
 
   while (true) {

--- a/src/visualisation/panel.cc
+++ b/src/visualisation/panel.cc
@@ -83,7 +83,7 @@ void VisualisationPanel::setData(const QByteArray &data) {
   minimap_->setSampler(minimap_sampler_);
   visualisation_->setSampler(sampler_);
   selection_label_->setText(prepareAddressString(0,
-                            sampler_->getFileOffset(sampler_->getSampleSize() - 1)));
+                            sampler_->getFileOffset(sampler_->getSampleSize())));
 
 }
 
@@ -129,7 +129,8 @@ VisualisationWidget* VisualisationPanel::getVisualisation(EVisualisation type,
 
 QString VisualisationPanel::prepareAddressString(size_t start, size_t end) {
   auto label = QString("0x%1 : ").arg(start, 8, 16, QChar('0'));
-  label.append(QString("0x%1").arg(end, 8, 16, QChar('0')));
+  label.append(QString("0x%1\n").arg(end, 8, 16, QChar('0')));
+  label.append(QString("(%1 bytes)").arg(end - start));
   return label;
 }
 


### PR DESCRIPTION
Bugfixes for a few known issues in minimap, mostly triggering for very small minimaps (with a few bytes):
 - crash by adding multiple minimaps of size 1
 - "dead pixels" (black) at the end of small minimaps
 - last byte of the file could not be included in selection
 - last part of minimap corresponded to way too large part of the file

Also added selection size in minimap view.