### PR TITLE
Schema cleanups & improvements

### DIFF
--- a/python/make_blob
+++ b/python/make_blob
@@ -9,7 +9,7 @@ with open(sys.argv[2], 'rb') as f:
     data = f.read()
 
 id = client.create(None,
-    tags=['blob', 'fileblob'],
+    tags={'blob', 'fileblob'},
     attr={
         'name': sys.argv[2],
     },

--- a/python/upload_elf
+++ b/python/upload_elf
@@ -9,7 +9,7 @@ with open(sys.argv[2], 'rb') as f:
     data = f.read()
 
 id = client.create(None,
-    tags=['blob', 'fileblob'],
+    tags={'blob', 'fileblob'},
     attr={
         'name': sys.argv[2],
     },
@@ -20,6 +20,6 @@ id = client.create(None,
 print('CREATED BLOB', id)
 h_id = client.create(id,
     pos=(0, None),
-    tags=['chunk', 'elf.ehdr'],
+    tags={'chunk', 'elf.ehdr'},
 )
 print('CREATED HEADER', h_id)

--- a/python/veles/asrv/proto.py
+++ b/python/veles/asrv/proto.py
@@ -135,7 +135,7 @@ class Proto(asyncio.Protocol):
         self.srv.remove_conn(self)
 
     def send_msg(self, msg):
-        self.transport.write(msg.dump(self.packer))
+        self.transport.write(self.packer.pack(msg.dump()))
 
     def msg_create(self, msg):
         self.srv.create(

--- a/python/veles/asrv/srv.py
+++ b/python/veles/asrv/srv.py
@@ -56,13 +56,10 @@ class BaseLister:
         if self.pos[1] is not None:
             if obj.pos_start is not None and obj.pos_start >= self.pos[1]:
                 return False
-        for tags in self.tags:
-            for k, v in tags:
-                if v != (k in obj.tags):
-                    break
-            else:
-                return True
-        return False
+        for tag in self.tags:
+            if tag not in obj.tags:
+                return False
+        return True
 
     def list_changed(self):
         raise NotImplementedError

--- a/python/veles/proto/exceptions.py
+++ b/python/veles/proto/exceptions.py
@@ -39,3 +39,8 @@ class ObjectExistsError(VelesException):
 class WritePastEndError(VelesException):
     code = 'write_past_end'
     msg = "Data written past the end of object"
+
+
+class SchemaError(VelesException):
+    code = 'schema_error'
+    msg = "Schema violation"

--- a/python/veles/proto/messages.py
+++ b/python/veles/proto/messages.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from veles.proto import node
-from veles.schema import nodeid, model, fields
+from veles.proto.node import Node
+from veles.schema import model, fields
 
 
 class MsgpackMsg(model.PolymorphicModel):
@@ -23,7 +23,7 @@ class MsgpackMsg(model.PolymorphicModel):
 class MsgConnect(MsgpackMsg):
     object_type = 'connect'
 
-    proto_version = fields.Integer(minimum=1)
+    proto_version = fields.SmallInteger(minimum=1)
     client_name = fields.String(optional=True)
     client_version = fields.String(optional=True)
     client_description = fields.String(optional=True)
@@ -34,7 +34,7 @@ class MsgConnect(MsgpackMsg):
 class MsgConnected(MsgpackMsg):
     object_type = 'connected'
 
-    proto_version = fields.Integer(minimum=1)
+    proto_version = fields.SmallInteger(minimum=1)
     server_name = fields.String()
     server_version = fields.String()
 
@@ -50,7 +50,7 @@ class MsgProtoError(MsgpackMsg):
     object_type = 'proto_error'
 
     code = fields.Integer()
-    msg = fields.String(optional=True)
+    msg = fields.String()
 
 
 class MsgRegisterMethod(MsgpackMsg):
@@ -64,11 +64,10 @@ class MsgRegisterTrigger(MsgpackMsg):
 class MsgList(MsgpackMsg):
     object_type = 'list'
 
-    parent = fields.Extension(obj_type=nodeid.NodeID, optional=True)
-    tags = fields.Array(elements_types=[fields.Map(
-        keys_types=[fields.String()], values_types=[fields.Boolean()])])
-    qid = fields.Integer()
-    sub = fields.Boolean()
+    parent = fields.NodeID(optional=True)
+    tags = fields.Set(fields.String())
+    qid = fields.SmallUnsignedInteger()
+    sub = fields.Boolean(default=False)
     pos_start = fields.Integer(optional=True)
     pos_end = fields.Integer(optional=True)
 
@@ -76,59 +75,57 @@ class MsgList(MsgpackMsg):
 class MsgCancelSub(MsgpackMsg):
     object_type = 'cancel_sub'
 
-    qid = fields.Integer()
+    qid = fields.SmallUnsignedInteger()
 
 
 class MsgSubCancelled(MsgpackMsg):
     object_type = 'sub_cancelled'
 
-    qid = fields.Integer()
+    qid = fields.SmallUnsignedInteger()
 
 
 class MsgObjGone(MsgpackMsg):
     object_type = 'obj_gone'
 
-    qid = fields.Integer()
+    qid = fields.SmallUnsignedInteger()
 
 
 class MsgListReply(MsgpackMsg):
     object_type = 'list_reply'
 
-    objs = fields.Array(elements_types=[fields.Object(
-        local_type=node.Node)])
-    gone = fields.Array(elements_types=[fields.Extension(
-        obj_type=nodeid.NodeID)])
-    qid = fields.Integer()
+    objs = fields.List(fields.Object(Node))
+    gone = fields.List(fields.NodeID())
+    qid = fields.SmallUnsignedInteger()
 
 
 class MsgGet(MsgpackMsg):
     object_type = 'get'
 
-    id = fields.Extension(obj_type=nodeid.NodeID)
-    qid = fields.Integer()
-    sub = fields.Boolean()
+    id = fields.NodeID()
+    qid = fields.SmallUnsignedInteger()
+    sub = fields.Boolean(default=False)
 
 
 class MsgGetReply(MsgpackMsg):
     object_type = 'get_reply'
 
-    qid = fields.Integer()
-    obj = fields.Object(local_type=node.Node)
+    qid = fields.SmallUnsignedInteger()
+    obj = fields.Object(Node)
 
 
 class MsgGetData(MsgpackMsg):
     object_type = 'get_data'
 
-    qid = fields.Integer()
-    id = fields.Extension(obj_type=nodeid.NodeID)
-    sub = fields.Boolean()
+    qid = fields.SmallUnsignedInteger()
+    id = fields.NodeID()
+    sub = fields.Boolean(default=False)
     key = fields.String()
 
 
 class MsgGetDataReply(MsgpackMsg):
     object_type = 'get_data_reply'
 
-    qid = fields.Integer()
+    qid = fields.SmallUnsignedInteger()
     data = fields.Any()
 
 
@@ -159,17 +156,16 @@ class MsgRegistryReply(MsgpackMsg):
 class MsgCreate(MsgpackMsg):
     object_type = 'create'
 
-    id = fields.Extension(obj_type=nodeid.NodeID)
-    rid = fields.Integer()
-    qid = fields.Integer(optional=True)
-    parent = fields.Extension(obj_type=nodeid.NodeID, optional=True)
+    id = fields.NodeID()
+    rid = fields.SmallUnsignedInteger()
+    qid = fields.SmallUnsignedInteger(optional=True)
+    parent = fields.NodeID(optional=True)
     pos_start = fields.Integer(optional=True)
     pos_end = fields.Integer(optional=True)
-    attr = fields.Map(optional=True, keys_types=[fields.String()])
-    tags = fields.Array(optional=True, elements_types=[fields.String()],
-                        local_type=set)
-    data = fields.Map(optional=True, keys_types=[fields.String()])
-    bindata = fields.Map(optional=True, keys_types=[fields.String()])
+    attr = fields.Map(fields.String(), fields.Any())
+    tags = fields.Set(fields.String())
+    data = fields.Map(fields.String(), fields.Any())
+    bindata = fields.Map(fields.String(), fields.Binary())
 
 
 class MsgModify(MsgpackMsg):
@@ -179,15 +175,14 @@ class MsgModify(MsgpackMsg):
 class MsgDelete(MsgpackMsg):
     object_type = 'delete'
 
-    rid = fields.Integer()
-    ids = fields.Array(
-        elements_types=[fields.Extension(obj_type=nodeid.NodeID)])
+    rid = fields.SmallUnsignedInteger()
+    ids = fields.List(fields.NodeID())
 
 
 class MsgAck(MsgpackMsg):
     object_type = 'ack'
 
-    rid = fields.Integer()
+    rid = fields.SmallUnsignedInteger()
 
 
 class MsgModifyError(MsgpackMsg):

--- a/python/veles/proto/msgpackwrap.py
+++ b/python/veles/proto/msgpackwrap.py
@@ -36,8 +36,6 @@ class MsgpackWrapper(pep487.NewObject):
 
     @classmethod
     def pack_obj(cls, obj):
-        if isinstance(obj, (set, frozenset)):
-            return list(obj)
         if isinstance(obj, nodeid.NodeID):
             return msgpack.ExtType(EXT_NODE_ID, obj.bytes)
         if isinstance(obj, BinData):
@@ -45,8 +43,6 @@ class MsgpackWrapper(pep487.NewObject):
             return msgpack.ExtType(EXT_BINDATA, width + obj.raw_data)
         if isinstance(obj, six.integer_types):
             return msgpack.ExtType(EXT_BIGINT, bigint_encode(obj))
-        if callable(getattr(obj, "to_dict", None)):
-            return obj.to_dict()
         raise TypeError('Object of unknown type {}'.format(obj))
 
     @classmethod

--- a/python/veles/proto/node.py
+++ b/python/veles/proto/node.py
@@ -12,18 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from veles.schema import nodeid, model, fields
+from veles.schema import model, fields
 
 
 class Node(model.Model):
-    id = fields.Extension(obj_type=nodeid.NodeID)
-    parent = fields.Extension(obj_type=nodeid.NodeID, optional=True)
+    id = fields.NodeID()
+    parent = fields.NodeID(optional=True)
     pos_start = fields.Integer(optional=True)
     pos_end = fields.Integer(optional=True)
-    tags = fields.Array(elements_types=[fields.String()],
-                        local_type=set, optional=True)
-    attr = fields.Map(keys_types=[fields.String()], optional=True)
-    data = fields.Array(elements_types=[fields.String()],
-                        local_type=set, optional=True)
-    bindata = fields.Map(keys_types=[fields.String()],
-                         values_types=[fields.Integer()], optional=True)
+    tags = fields.Set(fields.String())
+    attr = fields.Map(fields.String(), fields.Any())
+    data = fields.Set(fields.String())
+    bindata = fields.Map(fields.String(), fields.SmallUnsignedInteger())

--- a/python/veles/schema/fields.py
+++ b/python/veles/schema/fields.py
@@ -15,214 +15,252 @@
 import six
 
 from veles.compatibility import pep487
-from . import model
+from veles.proto.exceptions import SchemaError
+from veles.data import bindata
+from . import nodeid
 
 
 class Field(pep487.NewObject):
-    def __init__(self, optional=False):
+    def __init__(self, optional=False, default=None):
         self.name = None
+        if not isinstance(optional, bool):
+            raise TypeError('optional must be a bool')
         self.optional = optional
+        self.default = default
+        if default is not None:
+            if optional:
+                raise ValueError('if optional is True, default must be None')
+            self.validate(default)
 
     def __get__(self, instance, owner=None):
-        if self.optional:
-            return instance.__dict__.get(self.name, None)
-        else:
-            return instance.__dict__[self.name]
+        if instance is None:
+            return self
+        return instance.__dict__[self.name]
 
     def __set__(self, instance, value):
-        value = self.validate(value)
+        self.validate(value)
         instance.__dict__[self.name] = value
 
     def __set_name__(self, owner, name):
         self.name = name
 
-    def add_to_class(self, cls):
-        cls.fields.append(self)
-
     def validate(self, value):
-        if not self.optional and value is None:
-            raise ValueError(
-                'Attribute {} is not optional and can\'t be None.'.format(
-                    self.name))
+        if value is None:
+            if not self.optional:
+                raise SchemaError(
+                    'Attribute {} is not optional and can\'t be None.'.format(
+                        self.name))
+        else:
+            self._validate(value)
+
+    def _validate(self, value):
+        if not isinstance(value, self.value_type):
+            raise SchemaError('Attribute {} has to be {}.'.format(
+                self.name, self.value_type.__name__))
+
+    def load(self, value):
+        if value is None:
+            self.validate(None)
+            return None
+        else:
+            return self._load(value)
+
+    def _load(self, value):
+        self.validate(value)
+        return value
+
+    def dump(self, value):
+        if value is None:
+            return None
+        return self._dump(value)
+
+    def _dump(self, value):
         return value
 
 
 class Any(Field):
-    pass
+    value_type = object
 
 
 class Integer(Field):
-    def __init__(self, optional=False, minimum=None, maximum=None):
-        super(Integer, self).__init__(optional)
+    def __init__(self, optional=False, default=None,
+                 minimum=None, maximum=None):
+        if not isinstance(minimum, six.integer_types) and minimum is not None:
+            raise TypeError('minimum must be an int')
+        if not isinstance(maximum, six.integer_types) and maximum is not None:
+            raise TypeError('maximum must be an int or None')
+        if minimum is not None and maximum is not None and minimum > maximum:
+            raise ValueError('minimum must be less than maximum')
         self.minimum = minimum
         self.maximum = maximum
+        super(Integer, self).__init__(optional, default)
 
-    def validate(self, value):
-        super(Integer, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, six.integer_types):
-            raise ValueError('Attribute {} has to be int type.'.format(
+    def _validate(self, value):
+        if not isinstance(value, six.integer_types) or isinstance(value, bool):
+            raise SchemaError('Attribute {} has to be int type.'.format(
                 self.name))
         if self.minimum is not None and value < self.minimum:
-            raise ValueError('Attribute {} minimum value is {}.'.format(
+            raise SchemaError('Attribute {} minimum value is {}.'.format(
                 self.name, self.minimum))
         if self.maximum is not None and value > self.maximum:
-            raise ValueError('Attribute {} maximum value is {}.'.format(
+            raise SchemaError('Attribute {} maximum value is {}.'.format(
                 self.name, self.maximum))
-        return value
+
+
+class UnsignedInteger(Integer):
+    def __init__(self, optional=False, default=None,
+                 minimum=0, maximum=None):
+        if not isinstance(minimum, six.integer_types):
+            raise TypeError('minimum must be an int')
+        if minimum < 0:
+            raise ValueError('UnsignedInteger minimum must not be negative')
+        super(UnsignedInteger, self).__init__(
+            optional, default, minimum, maximum)
+
+
+INT64_MIN = -2**63
+INT64_MAX = 2**63-1
+UINT64_MAX = 2**64-1
+
+
+class SmallInteger(Integer):
+    def __init__(self, optional=False, default=None,
+                 minimum=INT64_MIN, maximum=INT64_MAX):
+        if not isinstance(minimum, six.integer_types):
+            raise TypeError('minimum must be an int')
+        if not isinstance(maximum, six.integer_types):
+            raise TypeError('maximum must be an int')
+        if minimum < INT64_MIN:
+            raise ValueError('SmallInteger minimum too small')
+        if maximum > INT64_MAX:
+            raise ValueError('SmallInteger maximum too large')
+        super(SmallInteger, self).__init__(
+            optional, default, minimum, maximum)
+
+
+class SmallUnsignedInteger(Integer):
+    def __init__(self, optional=False, default=None,
+                 minimum=0, maximum=UINT64_MAX):
+        if not isinstance(minimum, six.integer_types):
+            raise TypeError('minimum must be an int')
+        if not isinstance(maximum, six.integer_types):
+            raise TypeError('maximum must be an int')
+        if minimum < 0:
+            raise ValueError('SmallUnsignedInteger minimum too small')
+        if maximum > UINT64_MAX:
+            raise ValueError('SmallUnsignedInteger maximum too large')
+        super(SmallUnsignedInteger, self).__init__(
+            optional, default, minimum, maximum)
 
 
 class Boolean(Field):
-    def validate(self, value):
-        super(Boolean, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, bool):
-            raise ValueError('Attribute {} has to be bool type.'.format(
-                self.name))
-        return value
+    value_type = bool
 
 
 class Float(Field):
-    def validate(self, value):
-        super(Float, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, float):
-            raise ValueError('Attribute {} has to be float type.'.format(
-                self.name))
-        return value
+    value_type = float
 
 
 class String(Field):
-    def validate(self, value):
-        super(String, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, six.text_type):
-            raise ValueError('Attribute {} has to be str type.'.format(
-                self.name))
-        return value
+    value_type = six.text_type
 
 
 class Binary(Field):
-    def validate(self, value):
-        super(Binary, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, bytes):
-            raise ValueError('Attribute {} has to be bytes type.'.format(
-                self.name))
-        return value
+    value_type = bytes
 
 
-class Array(Field):
-    def __init__(self, optional=False, elements_types=None, local_type=list):
-        super(Array, self).__init__(optional)
-        self._allowed_local = (list, tuple, set, frozenset)
-        if elements_types:
-            self.elements_types = elements_types
-        else:
-            self.elements_types = [Any()]
-        if local_type not in self._allowed_local:
-            raise ValueError('Illegal local_type value')
-        self.local_type = local_type
+class NodeID(Field):
+    value_type = nodeid.NodeID
 
-    def validate(self, value):
-        super(Array, self).validate(value)
-        if value is None:
-            return []
-        if not isinstance(value, self._allowed_local):
-            raise ValueError(
-                'Attribute {} has to be one of {} type.'.format(
-                    self.name, self._allowed_local))
-        prep_value = []
+
+class BinData(Field):
+    value_type = bindata.BinData
+
+
+class Collection(Field):
+    def __init__(self, element, optional=False, default=Ellipsis):
+        if default is Ellipsis:
+            default = self.value_type()
+        if not isinstance(element, Field):
+            raise TypeError("Collection element must be a Field.")
+        self.element = element
+        super(Collection, self).__init__(optional, default)
+
+    def __set_name__(self, owner, name):
+        super(Collection, self).__set_name__(owner, name)
+        self.element.__set_name__(owner, name + '.element')
+
+    def _validate(self, value):
+        super(Collection, self)._validate(value)
         for val in value:
-            for element_type in self.elements_types:
-                try:
-                    prep_value.append(element_type.validate(val))
-                    break
-                except ValueError:
-                    pass
-            else:
-                raise ValueError(
-                    '{!r} doesn\'t fit in allowed element types'.format(val))
-        return self.local_type(prep_value)
+            self.element.validate(val)
+
+    def _load(self, value):
+        if not isinstance(value, list):
+            raise SchemaError(
+                'Attribute {} has to be a msgpack list'.format(self.name))
+        return self.value_type(
+            self.element.load(val)
+            for val in value
+        )
+
+    def _dump(self, value):
+        return [
+            self.element.dump(val)
+            for val in value
+        ]
+
+
+class List(Collection):
+    value_type = list
+
+
+class Set(Collection):
+    value_type = set
 
 
 class Map(Field):
-    def __init__(self, optional=False, keys_types=None, values_types=None):
-        super(Map, self).__init__(optional)
-        if keys_types:
-            self.keys_types = keys_types
-        else:
-            self.keys_types = [Any()]
-        if values_types:
-            self.values_types = values_types
-        else:
-            self.values_types = [Any()]
+    value_type = dict
 
-    def validate(self, value):
-        super(Map, self).validate(value)
-        if value is None:
-            return {}
+    def __init__(self, key, value, optional=False, default={}):
+        self.key = key
+        self.value = value
+        super(Map, self).__init__(optional, default)
+
+    def __set_name__(self, owner, name):
+        super(Map, self).__set_name__(owner, name)
+        self.key.__set_name__(owner, name + '.key')
+        self.value.__set_name__(owner, name + '.value')
+
+    def _validate(self, value):
+        super(Map, self)._validate(value)
+        for k, v in value.items():
+            self.key.validate(k)
+            self.value.validate(v)
+
+    def _load(self, value):
         if not isinstance(value, dict):
-            raise ValueError(
-                'Attribute {} has to be dict type.'.format(self.name))
-        for val in value.keys():
-            for key_type in self.keys_types:
-                try:
-                    key_type.validate(val)
-                    break
-                except ValueError:
-                    pass
-            else:
-                raise ValueError(
-                    '{!r} doesn\'t fit in allowed key types'.format(val))
-        prep_value = {}
-        for name, val in value.items():
-            for value_type in self.values_types:
-                try:
-                    prep_value[name] = value_type.validate(val)
-                    break
-                except ValueError:
-                    pass
-            else:
-                raise ValueError(
-                    '{} doesn\'t fit in allowed value types'.format(val))
-        return prep_value
+            raise SchemaError(
+                'Attribute {} has to be a dict'.format(self.name))
+        return {
+            self.key.load(k): self.value.load(v)
+            for k, v in value.items()
+        }
 
-
-class Extension(Field):
-    def __init__(self, obj_type, optional=False):
-        super(Extension, self).__init__(optional)
-        self.obj_type = obj_type
-
-    def validate(self, value):
-        super(Extension, self).validate(value)
-        if value is None:
-            return
-        if not isinstance(value, self.obj_type):
-            raise ValueError('Attribute {} has to be {} type.'.format(
-                self.name, self.obj_type))
-        return value
+    def _dump(self, value):
+        return {
+            self.key.dump(k): self.value.dump(v)
+            for k, v in value.items()
+        }
 
 
 class Object(Field):
-    def __init__(self, local_type, optional=False):
-        super(Object, self).__init__(optional)
-        assert issubclass(local_type, model.Model)
-        self.local_type = local_type
+    def __init__(self, value_type, optional=False, default=None):
+        self.value_type = value_type
+        super(Object, self).__init__(optional, default)
 
-    def validate(self, value):
-        super(Object, self).validate(value)
-        if isinstance(value, dict):
-            value = self.local_type.load(value)
+    def _load(self, value):
+        return self.value_type.load(value)
 
-        if isinstance(value, self.local_type):
-            return value
-
-        raise ValueError(
-            'Attribute {} has to be {} type or dict that maps to it.'.format(
-                self.name, self.local_type))
+    def _dump(self, value):
+        return value.dump()

--- a/python/veles/schema/model.py
+++ b/python/veles/schema/model.py
@@ -12,47 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from copy import copy
+
+import six
+
 from veles.compatibility import pep487
+from veles.proto.exceptions import SchemaError
+from . import fields
 
 
 class Model(pep487.NewObject):
+    fields = []
+
     def __init__(self, **kwargs):
-        if any(i not in [field.name for field in self.fields] for i in kwargs):
-            raise TypeError('got an unexpected keyword argument')
-        for field_name, field in kwargs.items():
-            setattr(self, field_name, field)
+        for field in self.fields:
+            if field.name in kwargs:
+                setattr(self, field.name, kwargs.pop(field.name))
+            else:
+                setattr(self, field.name, copy(field.default))
+        if kwargs:
+            raise TypeError('got an unexpected keyword argument {}'.format(
+                kwargs.popitem()[0]))
 
     def __init_subclass__(cls, **kwargs):
         super(Model, cls).__init_subclass__(**kwargs)
 
-        cls.fields = []
-        for klass in cls.__bases__ + (cls,):
-            for attr_name, attr in klass.__dict__.items():
-                try:
-                    attr.add_to_class(cls)
-                except AttributeError:
-                    pass
+        cls.fields = super(cls, cls).fields[:]
+        for attr in cls.__dict__.values():
+            if isinstance(attr, fields.Field):
+                cls.fields.append(attr)
 
-    def to_dict(self):
+    def dump(self):
         val = {}
         for field in self.fields:
-            val[field.name] = field.__get__(self)
+            val[six.text_type(field.name)] = field.dump(field.__get__(self))
         return val
 
     @classmethod
-    def from_dict(cls, val):
-        """Override if your class overrides __init__"""
-        return cls(**val)
-
-    @classmethod
     def load(cls, val):
-        return cls.from_dict(val)
-
-    def dump(self, packer):
-        return packer.pack(self.to_dict())
+        if not isinstance(val, dict):
+            raise SchemaError('a serialized model must be a dict')
+        val = dict(val)
+        args = {}
+        for field in cls.fields:
+            if field.name in val:
+                args[field.name] = field.load(val.pop(field.name))
+        if val:
+            raise SchemaError('got unexpected key {} in model {}'.format(
+                val.popitem()[0], cls.__name__))
+        return cls(**args)
 
     def __str__(self):
-        return '{}: {}'.format(self.__class__.__name__, self.to_dict())
+        return '{}({})'.format(type(self).__name__, ', '.join(
+            '{}={!r}'.format(field.name, field.__get__(self))
+            for field in self.fields
+        ))
+
+    def __eq__(self, other):
+        return type(self) == type(other) and self.__dict__ == other.__dict__
 
     __repr__ = __str__
 
@@ -64,35 +81,39 @@ class PolymorphicModel(Model):
     object_type = None
 
     def __init__(self, **kwargs):
-        assert self.object_type is not None, (
-            'Can\'t instantiate class {}'.format(self.__class__.__name__))
+        if self.object_type is None:
+            raise TypeError(
+                'Can\'t instantiate class {}'.format(type(self)))
         super(PolymorphicModel, self).__init__(**kwargs)
 
     def __init_subclass__(cls, **kwargs):
-        if cls.object_type is None:
-            cls.object_types = {}
-            return
-
         super(PolymorphicModel, cls).__init_subclass__(**kwargs)
 
-        assert cls.object_type not in cls.object_types, (
-            'object_type {} already used'.format(cls.object_type))
-        cls.object_types[cls.object_type] = cls
+        if not hasattr(cls, 'object_types'):
+            cls.object_types = {}
+        elif cls.object_type is not None:
+            if cls.object_type in cls.object_types:
+                raise TypeError(
+                    'object_type {} already used'.format(cls.object_type))
+            cls.object_types[cls.object_type] = cls
 
-    def to_dict(self):
-        val = super(PolymorphicModel, self).to_dict()
-        val['object_type'] = self.object_type
-        return val
+    def dump(self):
+        res = super(PolymorphicModel, self).dump()
+        res[u'object_type'] = self.object_type
+        return res
 
     @classmethod
     def load(cls, val):
-        if not isinstance(val, dict) or 'object_type' not in val:
-            raise ValueError('Malformed object')
-        if val['object_type'] not in cls.object_types:
-            raise ValueError('Unknown object type')
-        return cls.object_types[val.pop('object_type')].from_dict(val)
-
-    def __str__(self):
-        return '{}: {}'.format(self.object_type, self.to_dict())
-
-    __repr__ = __str__
+        if not isinstance(val, dict):
+            raise SchemaError('A serialized model must be a dict')
+        val = dict(val)
+        if 'object_type' not in val:
+            raise SchemaError('A polymorphic model has no type')
+        ot = val.pop('object_type')
+        if ot not in cls.object_types:
+            raise SchemaError('Unknown object type')
+        rcls = cls.object_types[ot]
+        if not issubclass(rcls, cls):
+            raise SchemaError('Object type not a subclass of {}'.format(
+                cls.__name__))
+        return super(PolymorphicModel, rcls).load(val)

--- a/python/veles/tests/schema/test_fields.py
+++ b/python/veles/tests/schema/test_fields.py
@@ -1,0 +1,422 @@
+# Copyright 2017 CodiLime
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import unittest
+
+from veles.data.bindata import BinData
+from veles.schema.nodeid import NodeID
+from veles.schema import fields
+from veles.proto.exceptions import SchemaError
+
+
+class Piwo(object):
+    def dump(self):
+        return 'piwo'
+
+    @classmethod
+    def load(cls, value):
+        if value != 'piwo':
+            raise SchemaError
+        return Piwo()
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __hash__(self):
+        return 13
+
+
+class Zlew(object):
+    def dump(self):
+        return 'zlew'
+
+    @classmethod
+    def load(cls, value):
+        if value != 'zlew':
+            raise SchemaError
+        return Zlew()
+
+    def __eq__(self, other):
+        return type(self) == type(other)
+
+    def __hash__(self):
+        return 13
+
+
+class TestFields(unittest.TestCase):
+    def test_field(self):
+        a = fields.Any(default='zlew')
+        a.__set_name__(None, 'a')
+        self.assertEqual(a.name, 'a')
+        a.validate(1234)
+        a.validate({})
+        with self.assertRaises(SchemaError):
+            a.validate(None)
+        tv = {
+            'a': 123,
+            'b': 'c',
+        }
+        self.assertEqual(a.dump(tv), tv)
+        self.assertEqual(a.load(tv), tv)
+        with self.assertRaises(SchemaError):
+            a.load(None)
+
+        with self.assertRaises(TypeError):
+            fields.Any(optional='zlew')
+        with self.assertRaises(ValueError):
+            a = fields.Any(optional=True, default='zlew')
+
+    def test_boolean(self):
+        with self.assertRaises(SchemaError):
+            fields.Boolean(default='zlew')
+
+        a = fields.Boolean(optional=True)
+        a.validate(True)
+        a.validate(False)
+        a.validate(None)
+        with self.assertRaises(SchemaError):
+            a.validate(1)
+        self.assertEqual(a.dump(None), None)
+        self.assertEqual(a.dump(True), True)
+        self.assertEqual(a.dump(False), False)
+        self.assertEqual(a.load(None), None)
+        self.assertEqual(a.load(True), True)
+        self.assertEqual(a.load(False), False)
+        with self.assertRaises(SchemaError):
+            a.load(1)
+
+    def test_float(self):
+        a = fields.Float()
+        a.validate(1.234)
+        with self.assertRaises(SchemaError):
+            a.validate(1)
+        with self.assertRaises(SchemaError):
+            a.validate('1.0')
+        self.assertEqual(a.dump(1.234), 1.234)
+        self.assertEqual(a.load(1.234), 1.234)
+        with self.assertRaises(SchemaError):
+            a.load(1)
+        with self.assertRaises(SchemaError):
+            a.load('1.0')
+
+    def test_string(self):
+        a = fields.String()
+        a.validate('abcd')
+        with self.assertRaises(SchemaError):
+            a.validate(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.validate(1234)
+        self.assertEqual(a.dump('abcd'), 'abcd')
+        self.assertEqual(a.load('abcd'), 'abcd')
+        with self.assertRaises(SchemaError):
+            a.load(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.load(1234)
+
+    def test_binary(self):
+        a = fields.Binary()
+        a.validate(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.validate('abcd')
+        with self.assertRaises(SchemaError):
+            a.validate(1234)
+        self.assertEqual(a.dump(b'abcd'), b'abcd')
+        self.assertEqual(a.load(b'abcd'), b'abcd')
+        with self.assertRaises(SchemaError):
+            a.load('abcd')
+        with self.assertRaises(SchemaError):
+            a.load(1234)
+
+    def test_nodeid(self):
+        a = fields.NodeID()
+        id = NodeID()
+        a.validate(id)
+        with self.assertRaises(SchemaError):
+            a.validate(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.validate(1234)
+        self.assertEqual(a.dump(id), id)
+        self.assertEqual(a.load(id), id)
+        with self.assertRaises(SchemaError):
+            a.load(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.load(1234)
+
+    def test_bindata(self):
+        a = fields.BinData()
+        data = BinData(8, [0x12, 0x34])
+        a.validate(data)
+        with self.assertRaises(SchemaError):
+            a.validate(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.validate(1234)
+        self.assertEqual(a.dump(data), data)
+        self.assertEqual(a.load(data), data)
+        with self.assertRaises(SchemaError):
+            a.load(b'abcd')
+        with self.assertRaises(SchemaError):
+            a.load(1234)
+
+    def test_integer(self):
+        a = fields.Integer()
+        a.validate(0)
+        a.validate(1)
+        a.validate(-1)
+        a.validate(0x123456789abcdef123456789abcdef)
+        a.validate(-0x123456789abcdef123456789abcdef)
+        with self.assertRaises(SchemaError):
+            a.validate(False)
+        with self.assertRaises(SchemaError):
+            a.validate(True)
+
+        a = fields.Integer(minimum=-123, maximum=456)
+        a.validate(-123)
+        a.validate(123)
+        a.validate(234)
+        a.validate(456)
+        with self.assertRaises(SchemaError):
+            a.validate(-0x123456789abcdef123456789abcdef)
+        with self.assertRaises(SchemaError):
+            a.validate(-124)
+        with self.assertRaises(SchemaError):
+            a.validate(457)
+        with self.assertRaises(SchemaError):
+            a.validate(0x123456789abcdef123456789abcdef)
+
+        a = fields.Integer(minimum=123)
+        a.validate(123)
+        a.validate(234)
+        a.validate(456)
+        a.validate(0x123456789abcdef123456789abcdef)
+        with self.assertRaises(SchemaError):
+            a.validate(0)
+        with self.assertRaises(SchemaError):
+            a.validate(-123)
+        with self.assertRaises(SchemaError):
+            a.validate(122)
+
+        with self.assertRaises(TypeError):
+            fields.Integer(minimum='zlew')
+        with self.assertRaises(TypeError):
+            fields.Integer(maximum='zlew')
+        fields.Integer(minimum=3, maximum=3)
+        fields.Integer(minimum=3)
+        fields.Integer(maximum=3)
+        with self.assertRaises(ValueError):
+            fields.Integer(minimum=3, maximum=2)
+
+    def test_unsigned_integer(self):
+        a = fields.UnsignedInteger()
+        a.validate(0)
+        a.validate(1)
+        a.validate(123)
+        a.validate(0x123456789abcdef123456789abcdef)
+        with self.assertRaises(SchemaError):
+            a.validate(-122)
+        with self.assertRaises(SchemaError):
+            a.validate(-1)
+        with self.assertRaises(SchemaError):
+            a.validate(-0x123456789abcdef123456789abcdef)
+
+        with self.assertRaises(ValueError):
+            fields.UnsignedInteger(minimum=-1)
+        with self.assertRaises(TypeError):
+            fields.UnsignedInteger(minimum=None)
+        with self.assertRaises(ValueError):
+            fields.UnsignedInteger(maximum=-1)
+        fields.UnsignedInteger(maximum=0)
+        fields.UnsignedInteger(minimum=123)
+        fields.UnsignedInteger(maximum=123)
+        fields.UnsignedInteger(maximum=None)
+
+    def test_small_integer(self):
+        a = fields.SmallInteger()
+        a.validate(0)
+        a.validate(-1)
+        a.validate(1)
+        a.validate(-0x8000000000000000)
+        a.validate(0x7fffffffffffffff)
+        with self.assertRaises(SchemaError):
+            a.validate(-0x8000000000000001)
+        with self.assertRaises(SchemaError):
+            a.validate(0x8000000000000000)
+        fields.SmallInteger(minimum=-1)
+        fields.SmallInteger(maximum=-1)
+        fields.SmallInteger(maximum=0x7fffffffffffffff)
+        fields.SmallInteger(minimum=-0x8000000000000000)
+        with self.assertRaises(ValueError):
+            fields.SmallInteger(maximum=0x8000000000000000)
+        with self.assertRaises(ValueError):
+            fields.SmallInteger(minimum=-0x8000000000000001)
+        with self.assertRaises(TypeError):
+            fields.SmallInteger(maximum=None)
+        with self.assertRaises(TypeError):
+            fields.SmallInteger(minimum=None)
+
+    def test_small_unsigned_integer(self):
+        a = fields.SmallUnsignedInteger()
+        a.validate(0)
+        a.validate(1)
+        a.validate(0xffffffffffffffff)
+        with self.assertRaises(SchemaError):
+            a.validate(-1)
+        with self.assertRaises(SchemaError):
+            a.validate(0x10000000000000000)
+        fields.SmallUnsignedInteger(minimum=1)
+        fields.SmallUnsignedInteger(maximum=1)
+        fields.SmallUnsignedInteger(maximum=0xffffffffffffffff)
+        fields.SmallUnsignedInteger(minimum=0)
+        with self.assertRaises(ValueError):
+            fields.SmallUnsignedInteger(maximum=0x10000000000000000)
+        with self.assertRaises(ValueError):
+            fields.SmallUnsignedInteger(minimum=-1)
+        with self.assertRaises(TypeError):
+            fields.SmallUnsignedInteger(maximum=None)
+        with self.assertRaises(TypeError):
+            fields.SmallUnsignedInteger(minimum=None)
+
+    def test_object(self):
+        a = fields.Object(Piwo, optional=True)
+        a.validate(None)
+        a.validate(Piwo())
+        with self.assertRaises(SchemaError):
+            a.validate('piwo')
+        with self.assertRaises(SchemaError):
+            a.validate(Zlew())
+        self.assertIsInstance(a.load('piwo'), Piwo)
+        with self.assertRaises(SchemaError):
+            a.load('zlew')
+        self.assertEqual(a.load(None), None)
+        self.assertEqual(a.dump(Piwo()), 'piwo')
+        self.assertEqual(a.dump(None), None)
+
+        a = fields.Object(Zlew)
+        a.validate(Zlew())
+        with self.assertRaises(SchemaError):
+            a.validate('zlew')
+        with self.assertRaises(SchemaError):
+            a.validate(Piwo())
+        with self.assertRaises(SchemaError):
+            a.validate(None)
+        self.assertIsInstance(a.load('zlew'), Zlew)
+        with self.assertRaises(SchemaError):
+            a.load('piwo')
+        with self.assertRaises(SchemaError):
+            a.load(None)
+        self.assertEqual(a.dump(Zlew()), 'zlew')
+
+        fields.Object(Zlew, default=Zlew())
+        with self.assertRaises(SchemaError):
+            fields.Object(Zlew, default=Piwo())
+
+    def test_list(self):
+        a = fields.List(fields.Object(Piwo))
+        a.validate([])
+        a.validate([Piwo()])
+        a.validate([Piwo(), Piwo(), Piwo()])
+        with self.assertRaises(SchemaError):
+            a.validate(Piwo())
+        with self.assertRaises(SchemaError):
+            a.validate(set())
+        with self.assertRaises(SchemaError):
+            a.validate(None)
+        with self.assertRaises(SchemaError):
+            a.validate([Piwo(), Zlew(), Piwo()])
+        with self.assertRaises(SchemaError):
+            a.validate([Piwo(), None])
+        self.assertEqual(a.load([]), [])
+        self.assertEqual(a.load(['piwo', 'piwo']), [Piwo(), Piwo()])
+        with self.assertRaises(SchemaError):
+            a.validate(a.load({}))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(None))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load('piwo'))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(['zlew']))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(['piwo', None]))
+        self.assertEqual(a.dump([]), [])
+        self.assertEqual(a.dump([Piwo(), Piwo()]), ['piwo', 'piwo'])
+        fields.List(fields.Integer(), default=[1, 2, 3])
+
+    def test_set(self):
+        a = fields.Set(fields.Object(Piwo))
+        a.validate(set())
+        a.validate({Piwo()})
+        with self.assertRaises(SchemaError):
+            a.validate(Piwo())
+        with self.assertRaises(SchemaError):
+            a.validate([])
+        with self.assertRaises(SchemaError):
+            a.validate(None)
+        with self.assertRaises(SchemaError):
+            a.validate({Piwo(), Zlew()})
+        with self.assertRaises(SchemaError):
+            a.validate({Piwo(), None})
+        self.assertEqual(a.load([]), set())
+        self.assertEqual(a.load(['piwo']), {Piwo()})
+        with self.assertRaises(SchemaError):
+            a.validate(a.load({}))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(None))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load('piwo'))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(['zlew']))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(['piwo', None]))
+        self.assertEqual(a.dump({}), [])
+        self.assertEqual(a.dump({Piwo()}), ['piwo'])
+        fields.Set(fields.Integer(), default={1, 2, 3})
+
+    def test_map(self):
+        a = fields.Map(fields.Object(Piwo), fields.Object(Zlew))
+        a.validate({})
+        a.validate({Piwo(): Zlew()})
+        with self.assertRaises(SchemaError):
+            a.validate(Piwo())
+        with self.assertRaises(SchemaError):
+            a.validate(Zlew())
+        with self.assertRaises(SchemaError):
+            a.validate([])
+        with self.assertRaises(SchemaError):
+            a.validate(None)
+        with self.assertRaises(SchemaError):
+            a.validate({Piwo(): Piwo()})
+        with self.assertRaises(SchemaError):
+            a.validate({Zlew(): Zlew()})
+        with self.assertRaises(SchemaError):
+            a.validate({Zlew(): Piwo()})
+        with self.assertRaises(SchemaError):
+            a.validate({Piwo(): None})
+        with self.assertRaises(SchemaError):
+            a.validate({None: Zlew()})
+        self.assertEqual(a.load({}), {})
+        self.assertEqual(a.load({'piwo': 'zlew'}), {Piwo(): Zlew()})
+        with self.assertRaises(SchemaError):
+            a.validate(a.load([]))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load(None))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load('piwo'))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load({'piwo': 'piwo'}))
+        with self.assertRaises(SchemaError):
+            a.validate(a.load({'piwo', 'zlew'}))
+        self.assertEqual(a.dump({}), {})
+        self.assertEqual(a.dump({Piwo(): Zlew()}), {'piwo': 'zlew'})
+        fields.Map(fields.Integer(), fields.String(), default={1: 'a'})

--- a/python/veles/tests/schema/test_model.py
+++ b/python/veles/tests/schema/test_model.py
@@ -1,0 +1,154 @@
+# Copyright 2017 CodiLime
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import unittest
+
+import six
+
+from veles.data.bindata import BinData
+from veles.schema import fields
+from veles.schema.model import Model
+from veles.proto.exceptions import SchemaError
+
+
+class Piwo(Model):
+    a = fields.Boolean()
+
+
+class Zlew(Model):
+    b = fields.List(fields.Map(fields.String(), fields.BinData()))
+
+
+class TurboZlew(Zlew):
+    c = fields.Set(fields.Binary())
+    d = fields.Object(Piwo)
+    e = fields.Integer(default=3)
+
+
+class TestModel(unittest.TestCase):
+    def test_field_name(self):
+        self.assertEqual(Piwo.a.name, 'a')
+        self.assertEqual(Zlew.b.name, 'b')
+        self.assertEqual(Zlew.b.element.name, 'b.element')
+        self.assertEqual(Zlew.b.element.key.name, 'b.element.key')
+        self.assertEqual(Zlew.b.element.value.name, 'b.element.value')
+        self.assertEqual(TurboZlew.c.name, 'c')
+        self.assertEqual(TurboZlew.c.element.name, 'c.element')
+        self.assertEqual(set(Piwo.fields), {Piwo.a})
+        self.assertEqual(set(Zlew.fields), {Zlew.b})
+        self.assertEqual(set(TurboZlew.fields), {
+            Zlew.b, TurboZlew.c, TurboZlew.d, TurboZlew.e})
+
+    def test_init(self):
+        a = Piwo(a=True)
+        b = Piwo(a=True)
+        c = Piwo(a=False)
+        d = Zlew()
+        e = TurboZlew(d=a)
+        self.assertEqual(a.a, True)
+        self.assertEqual(c.a, False)
+        self.assertEqual(d.b, [])
+        self.assertEqual(e.b, [])
+        self.assertEqual(e.c, set())
+        self.assertEqual(e.d, a)
+        self.assertEqual(e.e, 3)
+        self.assertEqual(a, a)
+        self.assertEqual(d, d)
+        self.assertEqual(e, e)
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+        self.assertNotEqual(a, d)
+        self.assertNotEqual(a, e)
+        self.assertNotEqual(d, e)
+        with self.assertRaises(SchemaError):
+            Piwo(a=None)
+        with self.assertRaises(SchemaError):
+            Piwo()
+        with self.assertRaises(TypeError):
+            Piwo(a=True, b='zlew')
+        with self.assertRaises(SchemaError):
+            TurboZlew()
+        with self.assertRaises(SchemaError):
+            TurboZlew(d=d)
+
+    def test_dump(self):
+        a = Piwo(a=True)
+        da = a.dump()
+        self.assertEqual(da, {'a': True})
+        for x in da:
+            self.assertIsInstance(x, six.text_type)
+
+        b = Zlew(b=[{'a': BinData(8, []), 'b': BinData(12, [0x123])}, {}])
+        db = b.dump()
+        self.assertEqual(db, {
+            'b': [
+                {
+                    'a': BinData(8, []),
+                    'b': BinData(12, [0x123]),
+                },
+                {},
+            ]
+        })
+        for x in db:
+            self.assertIsInstance(x, six.text_type)
+
+        c = TurboZlew(b=[{}], c={b'abc', b'def'}, d=Piwo(a=False), e=7)
+        dc = c.dump()
+        self.assertEqual(dc, {
+            'b': [{}],
+            'c': dc['c'],
+            'd': {'a': False},
+            'e': 7,
+        })
+        self.assertIsInstance(dc['c'], list)
+        self.assertEqual(set(dc['c']), {b'abc', b'def'})
+
+        d = TurboZlew(d=a)
+        dd = d.dump()
+        self.assertEqual(dd, {
+            'b': [],
+            'c': [],
+            'd': {'a': True},
+            'e': 3,
+        })
+
+    def test_load(self):
+        a = Piwo.load({
+            'a': True,
+        })
+        self.assertEqual(a, Piwo(a=True))
+        b = Zlew.load({})
+        self.assertEqual(b, Zlew())
+        c = Zlew.load({'b': [{}]})
+        self.assertEqual(c, Zlew(b=[{}]))
+        d = TurboZlew.load({
+            'd': {'a': True}
+        })
+        self.assertEqual(d, TurboZlew(d=a))
+        with self.assertRaises(SchemaError):
+            Piwo.load({})
+        with self.assertRaises(SchemaError):
+            Piwo.load({'a': None})
+        with self.assertRaises(SchemaError):
+            Piwo.load({'a': True, 'b': True})
+        with self.assertRaises(SchemaError):
+            Piwo.load('piwo')
+        with self.assertRaises(SchemaError):
+            Zlew.load([])
+        with self.assertRaises(SchemaError):
+            Zlew.load({'b': {}})
+        with self.assertRaises(SchemaError):
+            Zlew.load({'d': {'a': False}})

--- a/python/veles/tests/schema/test_polymodel.py
+++ b/python/veles/tests/schema/test_polymodel.py
@@ -1,0 +1,213 @@
+# Copyright 2017 CodiLime
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+
+import unittest
+
+import six
+
+from veles.schema import fields
+from veles.schema.model import PolymorphicModel
+from veles.proto.exceptions import SchemaError
+
+
+class BaseNieZlew(PolymorphicModel):
+    pass
+
+
+class NieZlew(BaseNieZlew):
+    object_type = 'nie_zlew'
+    pole = fields.String(optional=True)
+
+
+class BaseZlew(PolymorphicModel):
+    imie = fields.String(optional=True)
+
+
+class Zlew(BaseZlew):
+    object_type = 'zlew'
+    odplyw = fields.String()
+
+
+class TurboZlew(Zlew):
+    object_type = 'turbozlew'
+    dopalacz = fields.Binary()
+
+
+class WieloZlew(BaseZlew):
+    przeplyw = fields.Integer(default=13)
+
+
+class DwuZlew(WieloZlew):
+    object_type = 'dwuzlew'
+    lewy = fields.Object(Zlew)
+    prawy = fields.Object(Zlew)
+
+
+class PietroZlew(WieloZlew):
+    object_type = 'pietrozlew'
+    pietra = fields.List(fields.Object(BaseZlew))
+
+
+class TestModel(unittest.TestCase):
+    def test_fields(self):
+        self.assertEqual(set(BaseZlew.fields), {
+            BaseZlew.imie
+        })
+        self.assertEqual(set(Zlew.fields), {
+            BaseZlew.imie, Zlew.odplyw
+        })
+        self.assertEqual(set(TurboZlew.fields), {
+            BaseZlew.imie, Zlew.odplyw, TurboZlew.dopalacz
+        })
+        self.assertEqual(set(WieloZlew.fields), {
+            BaseZlew.imie, WieloZlew.przeplyw
+        })
+        self.assertEqual(set(DwuZlew.fields), {
+            BaseZlew.imie, WieloZlew.przeplyw, DwuZlew.lewy, DwuZlew.prawy
+        })
+        self.assertEqual(set(PietroZlew.fields), {
+            BaseZlew.imie, WieloZlew.przeplyw, PietroZlew.pietra
+        })
+
+    def test_object_types(self):
+        self.assertEqual(set(BaseZlew.object_types), {
+            'zlew', 'turbozlew', 'dwuzlew', 'pietrozlew',
+        })
+
+    def test_init(self):
+        a = Zlew(odplyw='o')
+        b = TurboZlew(odplyw='wzium', dopalacz=b'\xf3\x90')
+        c = DwuZlew(lewy=a, prawy=b)
+        d = PietroZlew(imie='Jasiu', pietra=[c], przeplyw=1)
+        with self.assertRaises(TypeError):
+            BaseZlew(imie='Sid')
+        with self.assertRaises(TypeError):
+            WieloZlew(imie='Legion')
+        with self.assertRaises(SchemaError):
+            DwuZlew(lewy=a, prawy=d)
+
+    def test_dump(self):
+        a = Zlew(odplyw='o')
+        b = TurboZlew(odplyw='wzium', dopalacz=b'\xf3\x90')
+        c = DwuZlew(lewy=a, prawy=b)
+        d = PietroZlew(imie='Jasiu', pietra=[c], przeplyw=1)
+        da = a.dump()
+        db = b.dump()
+        dc = c.dump()
+        dd = d.dump()
+        for x in da:
+            self.assertIsInstance(x, six.text_type)
+        for x in db:
+            self.assertIsInstance(x, six.text_type)
+        for x in dc:
+            self.assertIsInstance(x, six.text_type)
+        for x in dd:
+            self.assertIsInstance(x, six.text_type)
+        self.assertEqual(da, {
+            'object_type': 'zlew',
+            'imie': None,
+            'odplyw': 'o',
+        })
+        self.assertEqual(db, {
+            'object_type': 'turbozlew',
+            'imie': None,
+            'odplyw': 'wzium',
+            'dopalacz': b'\xf3\x90',
+        })
+        self.assertEqual(dc, {
+            'object_type': 'dwuzlew',
+            'imie': None,
+            'lewy': da,
+            'prawy': db,
+            'przeplyw': 13,
+        })
+        self.assertEqual(dd, {
+            'object_type': 'pietrozlew',
+            'imie': 'Jasiu',
+            'pietra': [dc],
+            'przeplyw': 1,
+        })
+
+    def test_load(self):
+        a = Zlew(odplyw='o')
+        b = TurboZlew(odplyw='wzium', dopalacz=b'\xf3\x90')
+        c = DwuZlew(lewy=a, prawy=b)
+        d = PietroZlew(imie='Jasiu', pietra=[c], przeplyw=1)
+        da = a.dump()
+        db = b.dump()
+        dc = c.dump()
+        dd = d.dump()
+        self.assertEqual(BaseZlew.load(da), a)
+        self.assertEqual(Zlew.load(da), a)
+        with self.assertRaises(SchemaError):
+            TurboZlew.load(da)
+        with self.assertRaises(SchemaError):
+            WieloZlew.load(da)
+        with self.assertRaises(SchemaError):
+            DwuZlew.load(da)
+        with self.assertRaises(SchemaError):
+            PietroZlew.load(da)
+        with self.assertRaises(SchemaError):
+            NieZlew.load(da)
+        with self.assertRaises(SchemaError):
+            BaseNieZlew.load(da)
+
+        self.assertEqual(BaseZlew.load(db), b)
+        self.assertEqual(Zlew.load(db), b)
+        self.assertEqual(TurboZlew.load(db), b)
+        with self.assertRaises(SchemaError):
+            WieloZlew.load(db)
+        with self.assertRaises(SchemaError):
+            DwuZlew.load(db)
+        with self.assertRaises(SchemaError):
+            PietroZlew.load(db)
+        with self.assertRaises(SchemaError):
+            NieZlew.load(db)
+        with self.assertRaises(SchemaError):
+            BaseNieZlew.load(db)
+
+        self.assertEqual(BaseZlew.load(dc), c)
+        self.assertEqual(WieloZlew.load(dc), c)
+        self.assertEqual(DwuZlew.load(dc), c)
+        with self.assertRaises(SchemaError):
+            Zlew.load(dc)
+        with self.assertRaises(SchemaError):
+            TurboZlew.load(dc)
+        with self.assertRaises(SchemaError):
+            PietroZlew.load(dc)
+        with self.assertRaises(SchemaError):
+            NieZlew.load(dc)
+        with self.assertRaises(SchemaError):
+            BaseNieZlew.load(dc)
+
+        self.assertEqual(BaseZlew.load(dd), d)
+        self.assertEqual(WieloZlew.load(dd), d)
+        self.assertEqual(PietroZlew.load(dd), d)
+        with self.assertRaises(SchemaError):
+            Zlew.load(dd)
+        with self.assertRaises(SchemaError):
+            TurboZlew.load(dd)
+        with self.assertRaises(SchemaError):
+            DwuZlew.load(dd)
+        with self.assertRaises(SchemaError):
+            NieZlew.load(dd)
+        with self.assertRaises(SchemaError):
+            BaseNieZlew.load(dd)
+
+        with self.assertRaises(SchemaError):
+            BaseZlew.load({})
+        with self.assertRaises(SchemaError):
+            BaseZlew.load({'object_type': 'nie_zlew'})


### PR DESCRIPTION
Changes:

- schema validation errors raise SchemaError.
- setting value of a field and deserializing it are now distinct operations
  and are more closely validated - it is now illegal to assign a dict to
  a model field, for example.
- Extension replaced with new NodeID and BinData fields.
- Array split into List and Set, which now only accept list/set, respectively.
- the type parameters of List/Set/Map now come before the optional parameter,
  and are intended to be used as positional params.
- a default value may now be set for a field.
- List/Set/Map have a default value of []/set()/{} by default.
- a new UnsignedInteger field is introduced (it's just an Integer with
  minimum=0)
- SmallInteger and SmallUnsignedInteger fields are introduced - these
  are limitted to int64_t and uint64_t range, respectively, and will
  be represented as such in C++.
- the dump method of model no longer takes a packer, and returns a dict
  instead.