### PR TITLE
schema.fields: Always call super().__init__ last.

### DIFF
--- a/python/veles/schema/fields.py
+++ b/python/veles/schema/fields.py
@@ -177,10 +177,10 @@ class BinData(Field):
 
 class List(Field):
     def __init__(self, element, optional=False, default=[]):
-        super(List, self).__init__(optional, default)
         if not isinstance(element, Field):
             raise TypeError("List element must be a Field.")
         self.element = element
+        super(List, self).__init__(optional, default)
 
     def __set_name__(self, owner, name):
         super(List, self).__set_name__(owner, name)
@@ -211,10 +211,10 @@ class List(Field):
 
 class Set(Field):
     def __init__(self, element, optional=False, default=set()):
-        super(Set, self).__init__(optional, default)
         if not isinstance(element, Field):
             raise TypeError("Set element must be a Field.")
         self.element = element
+        super(Set, self).__init__(optional, default)
 
     def __set_name__(self, owner, name):
         super(Set, self).__set_name__(owner, name)
@@ -245,9 +245,9 @@ class Set(Field):
 
 class Map(Field):
     def __init__(self, key, value, optional=False, default={}):
-        super(Map, self).__init__(optional, default)
         self.key = key
         self.value = value
+        super(Map, self).__init__(optional, default)
 
     def __set_name__(self, owner, name):
         super(Map, self).__set_name__(owner, name)
@@ -280,8 +280,8 @@ class Map(Field):
 
 class Object(Field):
     def __init__(self, value_type, optional=False, default=None):
-        super(Object, self).__init__(optional, default)
         self.value_type = value_type
+        super(Object, self).__init__(optional, default)
 
     def _load(self, value):
         if value is None:

--- a/python/veles/tests/schema/test_fields.py
+++ b/python/veles/tests/schema/test_fields.py
@@ -316,6 +316,10 @@ class TestFields(unittest.TestCase):
             a.load(None)
         self.assertEqual(a.dump(Zlew()), 'zlew')
 
+        fields.Object(Zlew, default=Zlew())
+        with self.assertRaises(SchemaError):
+            fields.Object(Zlew, default=Piwo())
+
     def test_list(self):
         a = fields.List(fields.Object(Piwo))
         a.validate([])
@@ -345,6 +349,7 @@ class TestFields(unittest.TestCase):
             a.validate(a.load(['piwo', None]))
         self.assertEqual(a.dump([]), [])
         self.assertEqual(a.dump([Piwo(), Piwo()]), ['piwo', 'piwo'])
+        fields.List(fields.Integer(), default=[1, 2, 3])
 
     def test_set(self):
         a = fields.Set(fields.Object(Piwo))
@@ -374,6 +379,7 @@ class TestFields(unittest.TestCase):
             a.validate(a.load(['piwo', None]))
         self.assertEqual(a.dump({}), [])
         self.assertEqual(a.dump({Piwo()}), ['piwo'])
+        fields.Set(fields.Integer(), default={1, 2, 3})
 
     def test_map(self):
         a = fields.Map(fields.Object(Piwo), fields.Object(Zlew))
@@ -411,3 +417,4 @@ class TestFields(unittest.TestCase):
             a.validate(a.load({'piwo', 'zlew'}))
         self.assertEqual(a.dump({}), {})
         self.assertEqual(a.dump({Piwo(): Zlew()}), {'piwo': 'zlew'})
+        fields.Map(fields.Integer(), fields.String(), default={1: 'a'})


### PR DESCRIPTION
Without this, validating a default value will fail.