### PR TITLE
Fix Python srv launcher on Windows

### DIFF
--- a/python/srv
+++ b/python/srv
@@ -41,7 +41,7 @@ else:
 print('Ready.')
 try:
     loop.add_signal_handler(signal.SIGINT, loop.stop)
-except AttributeError:
+except NotImplementedError:
     pass
 loop.run_forever()
 print('Goodbye.')


### PR DESCRIPTION
This is fix for regression introduced in PR #87 where wrong exception
type was assumed to be thrown by add_signal_handler on Windows