### PR TITLE
Many bugfixes and small improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,20 +188,19 @@ qt5_use_modules(parser Core)
 add_dependencies(parser zlib)
 target_link_libraries(parser veles_db veles_dbif ${ZLIB_LIBRARIES})
 
-set(MSGPACK_TMP_CPP ${CMAKE_CURRENT_BINARY_DIR}/messages-h4x.h)
 set(MSGPACK_CPP "${CMAKE_CURRENT_BINARY_DIR}/messages.h")
+set(PYTHON_DIR ${CMAKE_SOURCE_DIR}/python)
 
-add_custom_command(OUTPUT ${MSGPACK_TMP_CPP}
-  COMMAND ${PYEXE} -m veles.cpp.generate > ${MSGPACK_TMP_CPP}
+add_custom_command(OUTPUT ${MSGPACK_CPP}
+  COMMAND ${PYEXE} -m veles.cpp.generate > ${MSGPACK_CPP}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/python
   COMMENT "Generating msgpack C++ code from Python"
   DEPENDS cpp_python_gen
+    ${PYTHON_DIR}/veles/cpp/generate.py
+    ${PYTHON_DIR}/veles/proto/node.py
+    ${PYTHON_DIR}/veles/schema/model.py
+    ${PYTHON_DIR}/veles/schema/fields.py
   VERBATIM)
-
-# H4X make sure that messages.h is generated everytime no matter what
-add_custom_command(OUTPUT ${MSGPACK_CPP}
-  COMMAND ${CMAKE_COMMAND} -E rename ${MSGPACK_TMP_CPP} ${MSGPACK_CPP}
-  DEPENDS ${MSGPACK_TMP_CPP})
 
 add_library(veles_network
     ${MSGPACK_CPP}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,12 +198,15 @@ add_custom_command(OUTPUT ${MSGPACK_CPP}
   DEPENDS cpp_python_gen
     ${PYTHON_DIR}/veles/cpp/generate.py
     ${PYTHON_DIR}/veles/proto/node.py
+    ${PYTHON_DIR}/veles/proto/messages.py
+    ${PYTHON_DIR}/veles/proto/exceptions.py
     ${PYTHON_DIR}/veles/schema/model.py
     ${PYTHON_DIR}/veles/schema/fields.py
   VERBATIM)
 
 add_library(veles_network
     ${MSGPACK_CPP}
+    ${INCLUDE_DIR}/proto/exceptions.h
     ${INCLUDE_DIR}/network/msgpackwrapper.h
     ${INCLUDE_DIR}/network/msgpackobject.h
     ${SRC_DIR}/network/msgpackobject.cc

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ corresponding to the dependencies above.
 
 On Ubuntu it can be done like this::
 
-    apt-get install cmake zlib1g-dev qtbase5-dev python3 python3-virtualenv
+    apt-get install cmake zlib1g-dev qtbase5-dev python3 python3-venv
 
 To build ::
 

--- a/cmake/cppgen.cmake
+++ b/cmake/cppgen.cmake
@@ -1,26 +1,18 @@
-if(WIN32)
-  set(BASEPYEXE py.exe -3)
-else(WIN32)
-  set(BASEPYEXE python3)
-endif(WIN32)
-
 set(VENV_DIR ${CMAKE_CURRENT_BINARY_DIR}/msgpack-venv)
 
 if(WIN32)
+  set(BASEPYEXE py.exe -3)
   set(PYEXE ${VENV_DIR}/Scripts/python.exe)
+  set(SIX_LOC ${VENV_DIR}/Lib/site-packages/six.py)
 else(WIN32)
-  set(PYEXE ${VENV_DIR}/bin/python)
+  set(BASEPYEXE python3)
+  set(PYEXE ${VENV_DIR}/bin/python3)
+  set(SIX_LOC ${VENV_DIR}/lib/site-packages/six.py)
 endif(WIN32)
 
 add_custom_command(
   OUTPUT ${PYEXE}
-  COMMAND ${BASEPYEXE} -m virtualenv ${VENV_DIR})
-
-if(WIN32)
-  set(SIX_LOC ${VENV_DIR}/Lib/site-packages/six.py)
-else(WIN32)
-  set(SIX_LOC ${VENV_DIR}/lib/site-packages/six.py)
-endif(WIN32)
+  COMMAND ${BASEPYEXE} -m venv ${VENV_DIR})
 
 add_custom_command(
   OUTPUT ${SIX_LOC}

--- a/include/network/msgpackobject.h
+++ b/include/network/msgpackobject.h
@@ -26,11 +26,6 @@
 namespace veles {
 namespace messages {
 
-class ConversionException : public std::runtime_error {
- public:
-  ConversionException(const std::string& msg) : std::runtime_error(msg) {}
-};
-
 enum class ObjectType {
   NIL,
   BOOLEAN,

--- a/include/network/msgpackobject.h
+++ b/include/network/msgpackobject.h
@@ -26,6 +26,11 @@
 namespace veles {
 namespace messages {
 
+class ConversionException : public std::runtime_error {
+ public:
+  ConversionException(const std::string& msg) : std::runtime_error(msg) {}
+};
+
 enum class ObjectType {
   NIL,
   BOOLEAN,
@@ -75,6 +80,8 @@ class MsgpackObject {
     ~ObjectValue() {}
   } value;
 
+  void fromMsgpack(const msgpack::object& obj);
+
  public:
 
   MsgpackObject() : obj_type(ObjectType::NIL) {}
@@ -100,7 +107,6 @@ class MsgpackObject {
   MsgpackObject& operator=(const MsgpackObject& other);
 
   void destroyValue();
-  void fromMsgpack(const msgpack::object& obj);
 
   void msgpack_unpack(msgpack::object const& obj);
 

--- a/include/network/msgpackobject.h
+++ b/include/network/msgpackobject.h
@@ -40,8 +40,6 @@ enum class ObjectType {
 };
 
 class MsgpackObject {
-  // TODO do we want to allow change of object type, or do we want to create
-  // new one in such case?
   ObjectType obj_type;
 
   union ObjectValue{
@@ -76,8 +74,6 @@ class MsgpackObject {
   } value;
 
   void fromMsgpack(const msgpack::object& obj);
-  void validateGetUnsignedInt() const;
-  void validateGetSignedInt() const;
 
  public:
 
@@ -159,24 +155,29 @@ class MsgpackObject {
   }
 
   ObjectType type() const;
-  bool& getBool();
   bool getBool() const;
-  uint64_t& getUnsignedInt();
+  void setBool(bool val);
   uint64_t getUnsignedInt() const;
-  int64_t& getSignedInt();
+  void setUnsignedInt(uint64_t val);
   int64_t getSignedInt() const;
-  double& getDouble();
+  void setSignedInt(int64_t val);
   double getDouble() const;
+  void setDouble(double val);
   std::shared_ptr<std::string> getString();
   const std::shared_ptr<std::string> getString() const;
+  void setString(std::shared_ptr<std::string> val);
   std::shared_ptr<std::vector<uint8_t>> getBin();
   const std::shared_ptr<std::vector<uint8_t>> getBin() const;
+  void setBin(std::shared_ptr<std::vector<uint8_t>> val);
   std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> getArray();
   const std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> getArray() const;
+  void setArray(std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> val);
   std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> getMap();
   const std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> getMap() const;
+  void setMap(std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> val);
   std::pair<int, std::shared_ptr<std::vector<uint8_t>>> getExt();
   const std::pair<int, std::shared_ptr<std::vector<uint8_t>>> getExt() const;
+  void setExt(std::pair<int, std::shared_ptr<std::vector<uint8_t>>> val);
 private:
   void fromAnother(const MsgpackObject& other);
 };

--- a/include/network/msgpackobject.h
+++ b/include/network/msgpackobject.h
@@ -76,6 +76,8 @@ class MsgpackObject {
   } value;
 
   void fromMsgpack(const msgpack::object& obj);
+  void validateGetUnsignedInt() const;
+  void validateGetSignedInt() const;
 
  public:
 

--- a/python/veles/cpp/generate.py
+++ b/python/veles/cpp/generate.py
@@ -24,11 +24,11 @@ def generate_cpp_code():
     classes_to_generate = [node.Node, node.PosFilter]
     poly_classes = [messages.MsgpackMsg]
     for cls_type in classes_to_generate:
-        code += 'class {};\\\n'.format(cls_type.cpp_type()[0])
+        code += 'class {};\\\n'.format(cls_type.cpp_type())
     for cls_type in poly_classes:
-        code += 'class {};\\\n'.format(cls_type.cpp_type()[0])
+        code += 'class {};\\\n'.format(cls_type.cpp_type())
         for sub_class in cls_type.object_types.values():
-            code += 'class {};\\\n'.format(sub_class.cpp_type()[0])
+            code += 'class {};\\\n'.format(sub_class.cpp_type())
     for cls_type in classes_to_generate:
         code += cls_type.generate_header_code()
     for cls_type in poly_classes:
@@ -37,14 +37,6 @@ def generate_cpp_code():
             code += sub_class.generate_header_code()
 
     code += '\n'
-
-    code += '''#define MSGPACK_CLASSES_INIT \\
-  static void initMessages() {{\\
-{}\\
-  }}
-'''.format(
-        ''.join(['    {}::initObjectTypes();'.format(cls_type.cpp_type()[0])
-                 for cls_type in poly_classes]))
 
     code += '#define MSGPACK_CLASSES_SOURCE \\\n'
     for cls_type in classes_to_generate:

--- a/python/veles/cpp/generate.py
+++ b/python/veles/cpp/generate.py
@@ -32,7 +32,7 @@ def generate_cpp_code():
     for cls_type in classes_to_generate:
         code += cls_type.generate_header_code()
     for cls_type in poly_classes:
-        code += cls_type.generate_base_code()
+        code += cls_type.generate_base_header_code()
         for sub_class in cls_type.object_types.values():
             code += sub_class.generate_header_code()
 
@@ -42,6 +42,7 @@ def generate_cpp_code():
     for cls_type in classes_to_generate:
         code += cls_type.generate_source_code()
     for cls_type in poly_classes:
+        code += cls_type.generate_base_source_code()
         for sub_class in cls_type.object_types.values():
             code += sub_class.generate_source_code()
 

--- a/python/veles/proto/exceptions.py
+++ b/python/veles/proto/exceptions.py
@@ -61,7 +61,7 @@ class VelesException(Exception, NewObject):
 
     @classmethod
     def cpp_type(cls):
-        return 'veles::proto::VelesException', None
+        return 'veles::proto::VelesException'
 
     def __eq__(self, other):
         return (isinstance(other, VelesException)

--- a/python/veles/schema/fields.py
+++ b/python/veles/schema/fields.py
@@ -123,7 +123,8 @@ class Integer(Field):
     # TODO convert to use bignums
     def cpp_type(self):
         return ('int64_t', True,
-                self.default if self.default is not None else '0')
+                '{}ll'.format(self.default) if self.default is not None
+                else '0ll')
 
 
 class UnsignedInteger(Integer):
@@ -139,7 +140,8 @@ class UnsignedInteger(Integer):
     # TODO convert to use bignums
     def cpp_type(self):
         return ('uint64_t', True,
-                self.default if self.default is not None else '0')
+                '{}ull'.format(self.default) if self.default is not None
+                else '0ull')
 
 
 INT64_MIN = -2**63
@@ -163,7 +165,8 @@ class SmallInteger(Integer):
 
     def cpp_type(self):
         return ('int64_t', True,
-                self.default if self.default is not None else '0')
+                '{}ll'.format(self.default) if self.default is not None
+                else '0ll')
 
 
 class SmallUnsignedInteger(Integer):
@@ -182,7 +185,8 @@ class SmallUnsignedInteger(Integer):
 
     def cpp_type(self):
         return ('uint64_t', True,
-                self.default if self.default is not None else '0')
+                '{}ull'.format(self.default) if self.default is not None
+                else '0ull')
 
 
 class Boolean(Field):

--- a/python/veles/schema/fields.py
+++ b/python/veles/schema/fields.py
@@ -79,6 +79,13 @@ class Field(pep487.NewObject):
         return value
 
     def cpp_type(self):
+        """this function should return tuple containing three elements
+
+        first - C++ type name corresponding to this field
+        second - True if this type is POD or False if it should be wrapped
+         in smart pointer
+        third - default value
+        """
         raise NotImplementedError()
 
 
@@ -115,7 +122,8 @@ class Integer(Field):
 
     # TODO convert to use bignums
     def cpp_type(self):
-        return 'int64_t', True, '0'
+        return ('int64_t', True,
+                self.default if self.default is not None else '0')
 
 
 class UnsignedInteger(Integer):
@@ -130,7 +138,8 @@ class UnsignedInteger(Integer):
 
     # TODO convert to use bignums
     def cpp_type(self):
-        return 'uint64_t', True, '0'
+        return ('uint64_t', True,
+                self.default if self.default is not None else '0')
 
 
 INT64_MIN = -2**63
@@ -153,7 +162,8 @@ class SmallInteger(Integer):
             optional, default, minimum, maximum)
 
     def cpp_type(self):
-        return 'int64_t', True, '0'
+        return ('int64_t', True,
+                self.default if self.default is not None else '0')
 
 
 class SmallUnsignedInteger(Integer):
@@ -171,27 +181,34 @@ class SmallUnsignedInteger(Integer):
             optional, default, minimum, maximum)
 
     def cpp_type(self):
-        return 'uint64_t', True, '0'
+        return ('uint64_t', True,
+                self.default if self.default is not None else '0')
 
 
 class Boolean(Field):
     value_type = bool
 
     def cpp_type(self):
-        return 'bool', True, 'false'
+        if self.default is None:
+            default = 'false'
+        else:
+            default = 'true' if self.default else 'false'
+        return 'bool', True, default
 
 
 class Float(Field):
     value_type = float
 
     def cpp_type(self):
-        return 'double', True, '0.0'
+        return ('double', True,
+                self.default if self.default is not None else '0.0')
 
 
 class String(Field):
     value_type = six.text_type
 
     def cpp_type(self):
+        # TODO default value from self.default
         return 'std::string', False, 'nullptr'
 
 
@@ -199,6 +216,7 @@ class Binary(Field):
     value_type = bytes
 
     def cpp_type(self):
+        # TODO default value from self.default
         return 'std::vector<uint8_t>', False, 'nullptr'
 
 
@@ -206,6 +224,7 @@ class NodeID(Field):
     value_type = nodeid.NodeID
 
     def cpp_type(self):
+        # TODO default value from self.default
         return 'veles::data::NodeID', False, 'nullptr'
 
 
@@ -213,6 +232,7 @@ class BinData(Field):
     value_type = bindata.BinData
 
     def cpp_type(self):
+        # TODO default value from self.default
         return 'veles::data::BinData', False, 'nullptr'
 
 
@@ -254,6 +274,7 @@ class List(Collection):
     value_type = list
 
     def cpp_type(self):
+        # TODO default value from self.default
         elem_type = (
             '{}' if self.element.cpp_type()[1] else
             'std::shared_ptr<{}>').format(
@@ -265,6 +286,7 @@ class Set(Collection):
     value_type = set
 
     def cpp_type(self):
+        # TODO default value from self.default
         elem_type = (
             '{}' if self.element.cpp_type()[1] else
             'std::shared_ptr<{}>').format(
@@ -292,6 +314,7 @@ class Map(Field):
             self.value.validate(v)
 
     def cpp_type(self):
+        # TODO default value from self.default
         key_type = self.key.cpp_type()[0]
         value_type = (
             '{}' if self.value.cpp_type()[1] else
@@ -328,7 +351,8 @@ class Object(Field):
         return value.dump()
 
     def cpp_type(self):
-        return self.value_type.cpp_type()[0], False, 'nullptr'
+        # TODO default value from self.default
+        return self.value_type.cpp_type(), False, 'nullptr'
 
 
 class Enum(Field):

--- a/python/veles/schema/model.py
+++ b/python/veles/schema/model.py
@@ -182,13 +182,13 @@ if (it_{0} != obj->getMap()->end()'''.format(field.name)
   {2}\\
   b.set_{0}(obj_{0});\\
 }} else {{\\
-  throw ConversionException("Nonoptional field \
+  throw proto::SchemaError("Nonoptional field \
 {0} not found when unpacking");\\
 }}'''.format(field.name, arg_type, conv_func)
                 pack_code = ''
                 if not field.cpp_type()[1]:
                     pack_code += '''if (val->{0} == nullptr) {{\\
-  throw ConversionException("Nonoptional field {0} not set when packing");\\
+  throw proto::SchemaError("Nonoptional field {0} not set when packing");\\
 }}\\
 '''.format(field.name)
                 pack_code += '''msg["{0}"] = toMsgpackObject(val->{0});\\
@@ -317,7 +317,7 @@ createInstance(const std::shared_ptr<MsgpackObject> obj) {{\\
     auto loc_obj = std::make_shared<MsgpackObject>(obj);\\
     auto obj_type = *(*loc_obj->getMap())["object_type"]->getString();\\
     if (types.find(obj_type) ==  types.end()) {{\\
-      throw ConversionException("Unkown object_type: " + obj_type);\\
+      throw proto::SchemaError("Unkown object_type: " + obj_type);\\
     }}\\
     return types[obj_type](loc_obj);\\
   }}\\

--- a/src/network/msgpackobject.cc
+++ b/src/network/msgpackobject.cc
@@ -159,6 +159,18 @@ void MsgpackObject::fromMsgpack(const msgpack::v2::object &obj) {
   }
 }
 
+void MsgpackObject::validateGetUnsignedInt() const {
+  if (obj_type == ObjectType::UNSIGNED_INTEGER) return;
+  if (obj_type == ObjectType::SIGNED_INTEGER && value.uint <= LLONG_MAX) return;
+  throw proto::SchemaError("Wrong MsgpackObject type when trying to get unsigned int");
+}
+
+void MsgpackObject::validateGetSignedInt() const {
+  if (obj_type == ObjectType::SIGNED_INTEGER) return;
+  if (obj_type == ObjectType::UNSIGNED_INTEGER && value.uint <= LLONG_MAX) return;
+  throw proto::SchemaError("Wrong MsgpackObject type when trying to get signed int");
+}
+
 void MsgpackObject::msgpack_unpack(const msgpack::v2::object& obj) {
   destroyValue();
   fromMsgpack(obj);
@@ -179,22 +191,22 @@ bool MsgpackObject::getBool() const {
 }
 
 uint64_t& MsgpackObject::getUnsignedInt() {
-  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get unsigned int");
+  validateGetUnsignedInt();
   return value.uint;
 }
 
 uint64_t MsgpackObject::getUnsignedInt() const {
-  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get unsigned int");
+  validateGetUnsignedInt();
   return value.uint;
 }
 
 int64_t& MsgpackObject::getSignedInt() {
-  if (obj_type != ObjectType::SIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get signed int");
+  validateGetSignedInt();
   return value.sint;
 }
 
 int64_t MsgpackObject::getSignedInt() const {
-  if (obj_type != ObjectType::SIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get signed int");
+  validateGetSignedInt();
   return value.sint;
 }
 

--- a/src/network/msgpackobject.cc
+++ b/src/network/msgpackobject.cc
@@ -129,13 +129,25 @@ void MsgpackObject::fromMsgpack(const msgpack::v2::object &obj) {
     break;
   case msgpack::type::ARRAY:
     obj_type = ObjectType::ARRAY;
-    new (&value.array) std::shared_ptr<std::vector<MsgpackObject>>;
+    new (&value.array) std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>>;
     obj.convert(value.array);
+    // convert nullptr that got created from nils to MsgpackObject holding nil
+    for (auto& val : *value.array) {
+      if (val == nullptr) {
+        val = std::make_shared<MsgpackObject>();
+      }
+    }
     break;
   case msgpack::type::MAP:
     obj_type = ObjectType::MAP;
-    new (&value.map) std::shared_ptr<std::map<std::string, MsgpackObject>>;
+    new (&value.map) std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>>;
     obj.convert(value.map);
+    // convert nullptr that got created from nils to MsgpackObject holding nil
+    for (auto& it : *value.map) {
+      if (it.second == nullptr) {
+        it.second = std::make_shared<MsgpackObject>();
+      }
+    }
     break;
   case msgpack::type::EXT:
     obj_type = ObjectType::EXT;
@@ -157,74 +169,92 @@ ObjectType MsgpackObject::type() const {
 }
 
 bool& MsgpackObject::getBool() {
+  if (obj_type != ObjectType::BOOLEAN) throw ConversionException("Wrong MsgpackObject type when trying to get bool");
   return value.boolean;
 }
 
-bool MsgpackObject::getBool() const{
+bool MsgpackObject::getBool() const {
+  if (obj_type != ObjectType::BOOLEAN) throw ConversionException("Wrong MsgpackObject type when trying to get bool");
   return value.boolean;
 }
 
 uint64_t& MsgpackObject::getUnsignedInt() {
+  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get unsigned int");
   return value.uint;
 }
 
-uint64_t MsgpackObject::getUnsignedInt() const{
+uint64_t MsgpackObject::getUnsignedInt() const {
+  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get unsigned int");
   return value.uint;
 }
 
 int64_t& MsgpackObject::getSignedInt() {
+  if (obj_type != ObjectType::SIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get signed int");
   return value.sint;
 }
 
-int64_t MsgpackObject::getSignedInt() const{
+int64_t MsgpackObject::getSignedInt() const {
+  if (obj_type != ObjectType::SIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get signed int");
   return value.sint;
 }
 
 double& MsgpackObject::getDouble() {
+  if (obj_type != ObjectType::DOUBLE) throw ConversionException("Wrong MsgpackObject type when trying to get double");
   return value.dbl;
 }
 
-double MsgpackObject::getDouble() const{
+double MsgpackObject::getDouble() const {
+  if (obj_type != ObjectType::DOUBLE) throw ConversionException("Wrong MsgpackObject type when trying to get double");
   return value.dbl;
 }
 
 std::shared_ptr<std::string> MsgpackObject::getString() {
+  if (obj_type != ObjectType::STR) throw ConversionException("Wrong MsgpackObject type when trying to get string");
   return value.str;
 }
 
-const std::shared_ptr<std::string> MsgpackObject::getString() const{
+const std::shared_ptr<std::string> MsgpackObject::getString() const {
+  if (obj_type != ObjectType::STR) throw ConversionException("Wrong MsgpackObject type when trying to get string");
   return value.str;
 }
 
-std::shared_ptr<std::vector<uint8_t> > MsgpackObject::getBin() {
+std::shared_ptr<std::vector<uint8_t>> MsgpackObject::getBin() {
+  if (obj_type != ObjectType::BIN) throw ConversionException("Wrong MsgpackObject type when trying to get binary data");
   return value.bin;
 }
 
-const std::shared_ptr<std::vector<uint8_t> > MsgpackObject::getBin() const{
+const std::shared_ptr<std::vector<uint8_t>> MsgpackObject::getBin() const {
+  if (obj_type != ObjectType::BIN) throw ConversionException("Wrong MsgpackObject type when trying to get binary data");
   return value.bin;
 }
 
-std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject> > > MsgpackObject::getArray() {
+std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> MsgpackObject::getArray() {
+  if (obj_type != ObjectType::ARRAY) throw ConversionException("Wrong MsgpackObject type when trying to get array");
   return value.array;
 }
 
-const std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject> > > MsgpackObject::getArray() const{
+const std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> MsgpackObject::getArray() const {
+  if (obj_type != ObjectType::ARRAY) throw ConversionException("Wrong MsgpackObject type when trying to get array");
   return value.array;
 }
 
-std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject> > > MsgpackObject::getMap() {
+std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> MsgpackObject::getMap() {
+  if (obj_type != ObjectType::MAP) throw ConversionException("Wrong MsgpackObject type when trying to get map");
   return value.map;
 }
 
-const std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject> > > MsgpackObject::getMap() const{
+const std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> MsgpackObject::getMap() const {
+  if (obj_type != ObjectType::MAP) throw ConversionException("Wrong MsgpackObject type when trying to get map");
   return value.map;
 }
 
-std::pair<int, std::shared_ptr<std::vector<uint8_t> > > MsgpackObject::getExt() {
+std::pair<int, std::shared_ptr<std::vector<uint8_t>>> MsgpackObject::getExt() {
+  if (obj_type != ObjectType::EXT) throw ConversionException("Wrong MsgpackObject type when trying to get ext");
   return value.ext;
 }
 
-const std::pair<int, std::shared_ptr<std::vector<uint8_t> > > MsgpackObject::getExt() const{
+const std::pair<int, std::shared_ptr<std::vector<uint8_t>>> MsgpackObject::getExt() const {
+  if (obj_type != ObjectType::EXT) throw ConversionException("Wrong MsgpackObject type when trying to get ext");
   return value.ext;
 }
 
@@ -235,7 +265,6 @@ std::shared_ptr<MsgpackObject> toMsgpackObject(const std::vector<uint8_t>& val) 
 
 template<>
 std::shared_ptr<MsgpackObject> toMsgpackObject(const std::shared_ptr<std::vector<uint8_t>> val) {
-  if (val == nullptr) return nullptr;
   return std::make_shared<MsgpackObject>(val);
 }
 
@@ -244,7 +273,6 @@ std::shared_ptr<MsgpackObject> toMsgpackObject(const MsgpackObject& obj) {
 }
 
 std::shared_ptr<MsgpackObject> toMsgpackObject(const std::shared_ptr<MsgpackObject> obj) {
-  if (obj == nullptr) return nullptr;
   return obj;
 }
 
@@ -265,7 +293,6 @@ std::shared_ptr<MsgpackObject> toMsgpackObject(const std::string& val) {
 }
 
 std::shared_ptr<MsgpackObject> toMsgpackObject(const std::shared_ptr<std::string> val) {
-  if (val == nullptr) return nullptr;
   return std::make_shared<MsgpackObject>(val);
 }
 
@@ -274,7 +301,6 @@ std::shared_ptr<MsgpackObject> toMsgpackObject(const data::NodeID& val) {
 }
 
 std::shared_ptr<MsgpackObject> toMsgpackObject(const std::shared_ptr<data::NodeID> val) {
-  if (val == nullptr) return nullptr;
   return std::make_shared<MsgpackObject>(0, val->asVector());
 }
 
@@ -292,9 +318,7 @@ std::shared_ptr<MsgpackObject> toMsgpackObject(const double val) {
 }
 
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr<data::NodeID>& out) {
-  if (obj == nullptr) {
-    out = nullptr;
-  } else if (obj->type() == ObjectType::NIL) {
+  if (obj->type() == ObjectType::NIL) {
     out = std::make_shared<data::NodeID>(data::NodeID::NIL_VALUE);
   } else {
     out = std::make_shared<data::NodeID>(obj->getExt().second->data());
@@ -335,52 +359,27 @@ void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr
 }
 
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr<std::string>& out) {
-  if (obj == nullptr) {
-    out = nullptr;
-  } else {
-    out = obj->getString();
-  }
+  out = obj->getString();
 }
 
-void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr<std::vector<uint8_t> >& out) {
-  if (obj == nullptr) {
-    out = nullptr;
-  } else {
-    out = obj->getBin();
-  }
+void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr<std::vector<uint8_t>>& out) {
+  out = obj->getBin();
 }
 
-// TODO what to do if obj is nullptr ?
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, uint64_t& out) {
-  if (obj == nullptr) {
-    out = 0;
-  } else {
-    out = obj->getUnsignedInt();
-  }
+  out = obj->getUnsignedInt();
 }
 
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, int64_t& out) {
-  if (obj == nullptr) {
-    out = 0;
-  } else {
-    out = obj->getSignedInt();
-  }
+  out = obj->getSignedInt();
 }
 
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, bool& out) {
-  if (obj == nullptr) {
-    out = false;
-  } else {
-    out = obj->getBool();
-  }
+  out = obj->getBool();
 }
 
 void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, double& out) {
-  if (obj == nullptr) {
-    out = 0.0;
-  } else {
-    out = obj->getDouble();
-  }
+  out = obj->getDouble();
 }
 
 }  // namespace messages

--- a/src/network/msgpackobject.cc
+++ b/src/network/msgpackobject.cc
@@ -169,92 +169,92 @@ ObjectType MsgpackObject::type() const {
 }
 
 bool& MsgpackObject::getBool() {
-  if (obj_type != ObjectType::BOOLEAN) throw ConversionException("Wrong MsgpackObject type when trying to get bool");
+  if (obj_type != ObjectType::BOOLEAN) throw proto::SchemaError("Wrong MsgpackObject type when trying to get bool");
   return value.boolean;
 }
 
 bool MsgpackObject::getBool() const {
-  if (obj_type != ObjectType::BOOLEAN) throw ConversionException("Wrong MsgpackObject type when trying to get bool");
+  if (obj_type != ObjectType::BOOLEAN) throw proto::SchemaError("Wrong MsgpackObject type when trying to get bool");
   return value.boolean;
 }
 
 uint64_t& MsgpackObject::getUnsignedInt() {
-  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get unsigned int");
+  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get unsigned int");
   return value.uint;
 }
 
 uint64_t MsgpackObject::getUnsignedInt() const {
-  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get unsigned int");
+  if (obj_type != ObjectType::UNSIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get unsigned int");
   return value.uint;
 }
 
 int64_t& MsgpackObject::getSignedInt() {
-  if (obj_type != ObjectType::SIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get signed int");
+  if (obj_type != ObjectType::SIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get signed int");
   return value.sint;
 }
 
 int64_t MsgpackObject::getSignedInt() const {
-  if (obj_type != ObjectType::SIGNED_INTEGER) throw ConversionException("Wrong MsgpackObject type when trying to get signed int");
+  if (obj_type != ObjectType::SIGNED_INTEGER) throw proto::SchemaError("Wrong MsgpackObject type when trying to get signed int");
   return value.sint;
 }
 
 double& MsgpackObject::getDouble() {
-  if (obj_type != ObjectType::DOUBLE) throw ConversionException("Wrong MsgpackObject type when trying to get double");
+  if (obj_type != ObjectType::DOUBLE) throw proto::SchemaError("Wrong MsgpackObject type when trying to get double");
   return value.dbl;
 }
 
 double MsgpackObject::getDouble() const {
-  if (obj_type != ObjectType::DOUBLE) throw ConversionException("Wrong MsgpackObject type when trying to get double");
+  if (obj_type != ObjectType::DOUBLE) throw proto::SchemaError("Wrong MsgpackObject type when trying to get double");
   return value.dbl;
 }
 
 std::shared_ptr<std::string> MsgpackObject::getString() {
-  if (obj_type != ObjectType::STR) throw ConversionException("Wrong MsgpackObject type when trying to get string");
+  if (obj_type != ObjectType::STR) throw proto::SchemaError("Wrong MsgpackObject type when trying to get string");
   return value.str;
 }
 
 const std::shared_ptr<std::string> MsgpackObject::getString() const {
-  if (obj_type != ObjectType::STR) throw ConversionException("Wrong MsgpackObject type when trying to get string");
+  if (obj_type != ObjectType::STR) throw proto::SchemaError("Wrong MsgpackObject type when trying to get string");
   return value.str;
 }
 
 std::shared_ptr<std::vector<uint8_t>> MsgpackObject::getBin() {
-  if (obj_type != ObjectType::BIN) throw ConversionException("Wrong MsgpackObject type when trying to get binary data");
+  if (obj_type != ObjectType::BIN) throw proto::SchemaError("Wrong MsgpackObject type when trying to get binary data");
   return value.bin;
 }
 
 const std::shared_ptr<std::vector<uint8_t>> MsgpackObject::getBin() const {
-  if (obj_type != ObjectType::BIN) throw ConversionException("Wrong MsgpackObject type when trying to get binary data");
+  if (obj_type != ObjectType::BIN) throw proto::SchemaError("Wrong MsgpackObject type when trying to get binary data");
   return value.bin;
 }
 
 std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> MsgpackObject::getArray() {
-  if (obj_type != ObjectType::ARRAY) throw ConversionException("Wrong MsgpackObject type when trying to get array");
+  if (obj_type != ObjectType::ARRAY) throw proto::SchemaError("Wrong MsgpackObject type when trying to get array");
   return value.array;
 }
 
 const std::shared_ptr<std::vector<std::shared_ptr<MsgpackObject>>> MsgpackObject::getArray() const {
-  if (obj_type != ObjectType::ARRAY) throw ConversionException("Wrong MsgpackObject type when trying to get array");
+  if (obj_type != ObjectType::ARRAY) throw proto::SchemaError("Wrong MsgpackObject type when trying to get array");
   return value.array;
 }
 
 std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> MsgpackObject::getMap() {
-  if (obj_type != ObjectType::MAP) throw ConversionException("Wrong MsgpackObject type when trying to get map");
+  if (obj_type != ObjectType::MAP) throw proto::SchemaError("Wrong MsgpackObject type when trying to get map");
   return value.map;
 }
 
 const std::shared_ptr<std::map<std::string, std::shared_ptr<MsgpackObject>>> MsgpackObject::getMap() const {
-  if (obj_type != ObjectType::MAP) throw ConversionException("Wrong MsgpackObject type when trying to get map");
+  if (obj_type != ObjectType::MAP) throw proto::SchemaError("Wrong MsgpackObject type when trying to get map");
   return value.map;
 }
 
 std::pair<int, std::shared_ptr<std::vector<uint8_t>>> MsgpackObject::getExt() {
-  if (obj_type != ObjectType::EXT) throw ConversionException("Wrong MsgpackObject type when trying to get ext");
+  if (obj_type != ObjectType::EXT) throw proto::SchemaError("Wrong MsgpackObject type when trying to get ext");
   return value.ext;
 }
 
 const std::pair<int, std::shared_ptr<std::vector<uint8_t>>> MsgpackObject::getExt() const {
-  if (obj_type != ObjectType::EXT) throw ConversionException("Wrong MsgpackObject type when trying to get ext");
+  if (obj_type != ObjectType::EXT) throw proto::SchemaError("Wrong MsgpackObject type when trying to get ext");
   return value.ext;
 }
 


### PR DESCRIPTION
* Generate messages.h only when Python files it depends on changes
* Update README.rst
* use venv instead of virtualenv
* make fromMsgpack private
* check variant type when accessing MsgpackObject
  and throw ConversionException on mismatch
* use Python defaults in C++ code where it was easy to do
* remove unneeded returned None from cpp_type in Model class
* throw ConversionException when non-optional field is not set
  when trying to load or serialize Model
* Convert nullptr to Nil variant when unpacking msgpack::object
  to our MsgpackObject variant
* Add dumpObject to MsgpackWrapper to directly pack supported objects
  to msgpack packer
* Add method loadMessagePack to Model that loads it from msgpack::object
* Add method polymorphicLoad to PolymorphicModel that loads correct Model
  based on object_type value