### PR TITLE
Switched to #pragma once plus formatting fixes

### DIFF
--- a/include/data/bindata.h
+++ b/include/data/bindata.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DATA_BINDATA_H
-#define VELES_DATA_BINDATA_H
+#pragma once
 
 #include <QString>
 #include <assert.h>
@@ -311,5 +310,3 @@ class BinData {
 
 }  // namespace data
 }  // namespace veles
-
-#endif  // VELES_DATA_BINDATA_H

--- a/include/data/field.h
+++ b/include/data/field.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DATA_FIELD
-#define VELES_DATA_FIELD
+#pragma once
 
 #include "data/types.h"
 #include "data/bindata.h"
@@ -170,5 +169,3 @@ struct ChunkDataItem {
 
 }  // namespace data
 }  // namespace veles
-
-#endif  // VELES_DATA_FIELD

--- a/include/data/nodeid.h
+++ b/include/data/nodeid.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+#pragma once
 
 #include <sstream>
 

--- a/include/data/nodeid.h
+++ b/include/data/nodeid.h
@@ -15,8 +15,6 @@
  *
  */
 
-#ifndef VELES_DATA_MSGPACK_H
-#define VELES_DATA_MSGPACK_H
 #include <sstream>
 
 #include <msgpack.hpp>
@@ -44,4 +42,3 @@ class NodeID {
 
 }  // namespace data
 }  // namespace veles
-#endif // VELES_DATA_MSGPACK_H

--- a/include/data/repack.h
+++ b/include/data/repack.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DATA_REPACK_H
-#define VELES_DATA_REPACK_H
+#pragma once
 
 #include "data/bindata.h"
 
@@ -81,6 +80,3 @@ struct Repacker {
 
 }  // namespace data
 }  // namespace veles
-
-#endif  // VELES_DATA_REPACK_H
-

--- a/include/data/types.h
+++ b/include/data/types.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DATA_TYPES
-#define VELES_DATA_TYPES
+#pragma once
 
 #include <QSharedPointer>
 
@@ -31,5 +30,3 @@ using dbif::ObjectHandle;
 }  // namespace data
 
 }  // namespace veles
-
-#endif  // VELES_DATA_TYPES

--- a/include/db/db.h
+++ b/include/db/db.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_DB_H
-#define VELES_DB_DB_H
+#pragma once
 
 #include "dbif/types.h"
 
@@ -24,7 +23,5 @@ namespace db {
 
 dbif::ObjectHandle create_db();
 
-};
-};
-
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/db/getter.h
+++ b/include/db/getter.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_GETTER_H
-#define VELES_DB_GETTER_H
+#pragma once
 
 #include <QObject>
 #include "db/types.h"
@@ -63,7 +62,5 @@ class MethodRunner : public QObject {
   MethodRunner *forwarder(QThread *thread);
 };
 
-};
-};
-
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/db/handle.h
+++ b/include/db/handle.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_HANDLE_H
-#define VELES_DB_HANDLE_H
+#pragma once
 
 #include "dbif/universe.h"
 #include "dbif/types.h"
@@ -40,7 +39,5 @@ class LocalObjectHandle : public dbif::ObjectHandleBase {
   PLocalObject obj() const { return obj_; }
 };
 
-};
-};
-
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/db/object.h
+++ b/include/db/object.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_OBJECT_H
-#define VELES_DB_OBJECT_H
+#pragma once
 
 #include <atomic>
 
@@ -194,7 +193,5 @@ class ChunkObject : public LocalObject {
   const std::vector<data::ChunkDataItem>& items() const { return items_; }
 };
 
-};
-};
-
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/db/types.h
+++ b/include/db/types.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_TYPES
-#define VELES_DB_TYPES
+#pragma once
 
 #include <QObject>
 #include <QSharedPointer>
@@ -42,7 +41,5 @@ using dbif::PError;
 typedef QSharedPointer<LocalObject> PLocalObject;
 typedef QWeakPointer<LocalObject> WLocalObject;
 
-};
-};
-
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/db/universe.h
+++ b/include/db/universe.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DB_UNIVERSE_H
-#define VELES_DB_UNIVERSE_H
+#pragma once
 
 #include <QObject>
 #include <QStringList>
@@ -74,7 +73,6 @@ class Universe : public QObject {
       quint64 start = 0,
       veles::dbif::ObjectHandle parent_chunk = veles::dbif::ObjectHandle());
 };
-};
-};
 
-#endif
+}  // namespace db
+}  // namespace veles

--- a/include/dbif/error.h
+++ b/include/dbif/error.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_ERROR
-#define VELES_DBIF_ERROR
+#pragma once
 
 #include <stdint.h>
 #include <vector>
@@ -39,7 +38,5 @@ struct BlobDataInvalidRangeError : Error {};
 struct BlobDataInvalidWidthError : Error {};
 struct InvalidTypeError : Error {};
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/dbif/info.h
+++ b/include/dbif/info.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_INFO_H
-#define VELES_DBIF_INFO_H
+#pragma once
 
 #include <stdint.h>
 #include <vector>
@@ -149,7 +148,5 @@ struct ChunkDataReply : InfoReply {
     items(items) {}
 };
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/dbif/method.h
+++ b/include/dbif/method.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_METHOD_H
-#define VELES_DBIF_METHOD_H
+#pragma once
 
 #include <stdint.h>
 #include <vector>
@@ -127,7 +126,7 @@ struct BlobParseRequest : MethodRequest {
   ObjectHandle parent_chunk;
   BlobParseRequest(QString parser_id = "", uint64_t start = 0,
                    ObjectHandle parent_chunk = ObjectHandle())
-      : parser_id(parser_id), start(start), parent_chunk(parent_chunk){};
+      : parser_id(parser_id), start(start), parent_chunk(parent_chunk){}
   typedef NullReply ReplyType;
 };
 
@@ -147,7 +146,5 @@ struct CreatedReply : MethodReply {
   explicit CreatedReply(ObjectHandle object) : object(object) {}
 };
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/dbif/promise.h
+++ b/include/dbif/promise.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_PROMISE
-#define VELES_DBIF_PROMISE
+#pragma once
 
 #include <QObject>
 
@@ -40,7 +39,5 @@ class MethodResultPromise : public QObject {
   void gotError(veles::dbif::PError x);
 };
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/dbif/types.h
+++ b/include/dbif/types.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_TYPES
-#define VELES_DBIF_TYPES
+#pragma once
 
 #include <QSharedPointer>
 #include "data/types.h"
@@ -43,7 +42,5 @@ enum ObjectType {
   CHUNK,
 };
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/dbif/universe.h
+++ b/include/dbif/universe.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_DBIF_UNIVERSE
-#define VELES_DBIF_UNIVERSE
+#pragma once
 
 #include <QObject>
 #include <QCoreApplication>
@@ -126,7 +125,5 @@ class ObjectHandleBase {
   }
 };
 
-};
-};
-
-#endif
+}  // namespace dbif
+}  // namespace veles

--- a/include/network/msgpackobject.h
+++ b/include/network/msgpackobject.h
@@ -14,9 +14,7 @@
  * limitations under the License.
  *
  */
-
-#ifndef VELES_MSGPACKOBJECT_H
-#define VELES_MSGPACKOBJECT_H
+#pragma once
 
 #include <msgpack.hpp>
 
@@ -364,5 +362,3 @@ void fromMsgpackObject(const std::shared_ptr<MsgpackObject> obj, std::shared_ptr
 
 }  // namespace messages
 }  // namespace veles
-
-#endif // VELES_MSGPACKOBJECT_H

--- a/include/network/msgpackwrapper.h
+++ b/include/network/msgpackwrapper.h
@@ -14,9 +14,7 @@
  * limitations under the License.
  *
  */
-
-#ifndef VELES_MSGPACK_H
-#define VELES_MSGPACK_H
+#pragma once
 
 #include <msgpack.hpp>
 #include <QtNetwork/QTcpSocket>
@@ -74,5 +72,3 @@ class MsgpackWrapper {
 
 }  // namespace messages
 }  // namespace veles
-
-#endif // VELES_MSGPACK_H

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_PARSER_PARSER_H
-#define VELES_PARSER_PARSER_H
+#pragma once
 
 #include <QString>
 #include "data/bindata.h"
@@ -45,5 +44,3 @@ class Parser {
 
 }  // namespace parser
 }  // namespace veles
-
-#endif  // VELES_PARSER_PARSER_H

--- a/include/parser/stream.h
+++ b/include/parser/stream.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_PARSER_STREAM_H
-#define VELES_PARSER_STREAM_H
+#pragma once
 
 #include <assert.h>
 
@@ -294,7 +293,6 @@ class StreamParser {
   }
 
 };
-};
-};
 
-#endif
+}  // namespace parser
+}  // namespace veles

--- a/include/parser/unpng.h
+++ b/include/parser/unpng.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_PARSER_UNPNG_H
-#define VELES_PARSER_UNPNG_H
+#pragma once
 
 #include "data/bindata.h"
 #include "dbif/types.h"
@@ -38,5 +37,3 @@ class PngParser : public Parser {
 
 }  // namespace parser
 }  // namespace veles
-
-#endif

--- a/include/parser/unpyc.h
+++ b/include/parser/unpyc.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_PARSER_UNPYC_H
-#define VELES_PARSER_UNPYC_H
+#pragma once
 
 #include "data/bindata.h"
 #include "dbif/types.h"
@@ -42,5 +41,3 @@ class PycParser : public Parser {
 
 }  // namespace parser
 }  // namespace veles
-
-#endif

--- a/include/parser/utils.h
+++ b/include/parser/utils.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_PARSER_UTILS_H
-#define VELES_PARSER_UTILS_H
+#pragma once
 
 #include <QList>
 
@@ -30,7 +29,6 @@ data::ChunkDataItem findField(dbif::ObjectHandle parent, const QString &name);
 dbif::ObjectHandle makeSubBlob(dbif::ObjectHandle parent, const QString &name,
                                const data::BinData &data);
 QList<Parser *> createAllParsers();
-}
-}
 
-#endif
+}  // namespace parser
+}  // namespace veles

--- a/include/ui/connectiondialog.h
+++ b/include/ui/connectiondialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_CONNECTIONDIALOG_H
-#define VELES_UI_CONNECTIONDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QFileDialog>
@@ -68,5 +67,3 @@ class ConnectionDialog : public QDialog {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // VELES_UI_CONNECTIONDIALOG_H

--- a/include/ui/connectionmanager.h
+++ b/include/ui/connectionmanager.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_CONNECTIONMANAGER_H
-#define VELES_UI_CONNECTIONMANAGER_H
+#pragma once
 
 #include <QObject>
 #include <QString>
@@ -103,5 +102,3 @@ class ConnectionNotificationWidget : public QWidget {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_CONNECTIONMANAGER_H

--- a/include/ui/createchunkdialog.h
+++ b/include/ui/createchunkdialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef CREATECHUNKDIALOG_H
-#define CREATECHUNKDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QItemSelectionModel>
@@ -61,5 +60,3 @@ class CreateChunkDialog : public QDialog {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // CREATECHUNKDIALOG_H

--- a/include/ui/databaseinfo.h
+++ b/include/ui/databaseinfo.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef DATABASEINFO_H
-#define DATABASEINFO_H
+#pragma once
 
 #include <QMap>
 #include <QStandardItemModel>
@@ -62,5 +61,3 @@ class DatabaseInfo : public QWidget {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // DATABASEINFO_H

--- a/include/ui/dockwidget.h
+++ b/include/ui/dockwidget.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_DOCKWIDGET_H
-#define VELES_UI_DOCKWIDGET_H
+#pragma once
 
 #include <set>
 #include <map>
@@ -267,5 +266,3 @@ class MainWindowWithDetachableDockWidgets: public QMainWindow {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_DOCKWIDGET_H

--- a/include/ui/dockwidget_native.h
+++ b/include/ui/dockwidget_native.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_DOCKWIDGET_NATIVE_H
-#define VELES_UI_DOCKWIDGET_NATIVE_H
+#pragma once
 
 #include <QTabBar>
 #include <QDockWidget>
@@ -28,5 +27,3 @@ void startDockDragging(QDockWidget* object);
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_DOCKWIDGET_NATIVE_H

--- a/include/ui/fileblobitem.h
+++ b/include/ui/fileblobitem.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef FILEBLOBITEM_H
-#define FILEBLOBITEM_H
+#pragma once
 
 #include <QList>
 #include <QObject>
@@ -85,5 +84,3 @@ class FileBlobItem : public QObject {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // FILEBLOBITEM_H

--- a/include/ui/fileblobmodel.h
+++ b/include/ui/fileblobmodel.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef FILEBLOBMODEL_H
-#define FILEBLOBMODEL_H
+#pragma once
 
 #include <QAbstractItemModel>
 #include <QBuffer>
@@ -100,5 +99,3 @@ class FileBlobModel : public QAbstractItemModel {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // FILEBLOBMODEL_H

--- a/include/ui/gotoaddressdialog.h
+++ b/include/ui/gotoaddressdialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_GOTOADDRESSDIALOG_H
-#define VELES_UI_GOTOADDRESSDIALOG_H
+#pragma once
 
 #include <QDialog>
 
@@ -46,5 +45,3 @@ class GoToAddressDialog : public QDialog {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // VELES_UI_GOTOADDRESSDIALOG_H

--- a/include/ui/hexedit.h
+++ b/include/ui/hexedit.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_HEXEDIT_H
-#define VELES_UI_HEXEDIT_H
+#pragma once
 
 #include <QAbstractScrollArea>
 #include <QItemSelectionModel>
@@ -159,5 +158,3 @@ class HexEdit : public QAbstractScrollArea {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // VELES_UI_HEXEDIT_H

--- a/include/ui/hexeditwidget.h
+++ b/include/ui/hexeditwidget.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_HEXEDITWIDGET_H
-#define VELES_UI_HEXEDITWIDGET_H
+#pragma once
 
 #include <QGroupBox>
 #include <QLabel>
@@ -123,5 +122,3 @@ class HexEditWidget : public View {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_HEXEDITWIDGET_H

--- a/include/ui/logwidget.h
+++ b/include/ui/logwidget.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_LOGWIDGET_H
-#define VELES_UI_LOGWIDGET_H
+#pragma once
 
 #include <QMainWindow>
 #include <QIODevice>
@@ -92,5 +91,3 @@ class LogWidget : public QMainWindow {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif //VELES_UI_LOGWIDGET_H

--- a/include/ui/nodetreewidget.h
+++ b/include/ui/nodetreewidget.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_NODETREEWIDGET_H
-#define VELES_UI_NODETREEWIDGET_H
+#pragma once
 
 #include <QGroupBox>
 #include <QLabel>
@@ -100,5 +99,3 @@ class NodeTreeWidget : public View {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_NODETREEWIDGET_H

--- a/include/ui/nodewidget.h
+++ b/include/ui/nodewidget.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UI_NODEWIDGET_H
-#define VELES_UI_NODEWIDGET_H
+#pragma once
 
 #include <QWidget>
 #include <QStringList>
@@ -70,5 +69,3 @@ class NodeWidget : public View {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // VELES_UI_NODEWIDGET_H

--- a/include/ui/optionsdialog.h
+++ b/include/ui/optionsdialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef OPTIONSDIALOG_H
-#define OPTIONSDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QtCore>
@@ -42,5 +41,3 @@ class OptionsDialog : public QDialog {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // OPTIONSDIALOG_H

--- a/include/ui/rootfileblobitem.h
+++ b/include/ui/rootfileblobitem.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef ROOTFILEBLOBITEM_H
-#define ROOTFILEBLOBITEM_H
+#pragma once
 
 #include <QList>
 #include <QObject>
@@ -40,5 +39,3 @@ class RootFileBlobItem : public FileBlobItem {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // ROOTFILEBLOBITEM_H

--- a/include/ui/searchdialog.h
+++ b/include/ui/searchdialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef SEARCHDIALOG_H
-#define SEARCHDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QtCore>
@@ -65,5 +64,3 @@ class SearchDialog : public QDialog {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // SEARCHDIALOG_H

--- a/include/ui/simplefileblobitem.h
+++ b/include/ui/simplefileblobitem.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef SIMPLEFILEBLOBITEM_H
-#define SIMPLEFILEBLOBITEM_H
+#pragma once
 
 #include <QObject>
 
@@ -31,11 +30,12 @@ class SimpleFileBlobItem : public FileBlobItem {
   Q_OBJECT
 
  public:
-  SimpleFileBlobItem(QString name, QString comment, QObject *parent = 0) : FileBlobItem(name, "", comment, 0, 0, parent) {};
-  bool range(uint64_t *start, uint64_t *end) const override {return false;}
+  SimpleFileBlobItem(QString name, QString comment, QObject *parent = 0)
+    : FileBlobItem(name, "", comment, 0, 0, parent) {}
+  bool range(uint64_t *start, uint64_t *end) const override {
+    return false;
+  }
 };
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // SIMPLEFILEBLOBITEM_H

--- a/include/ui/slice.h
+++ b/include/ui/slice.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef SLICE_H
-#define SLICE_H
+#pragma once
 
 #include <stdint.h>
 
@@ -40,5 +39,3 @@ class SliceStorage {};
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // SLICE_H

--- a/include/ui/spinbox.h
+++ b/include/ui/spinbox.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef UI_SPINBOX_H
-#define UI_SPINBOX_H
+#pragma once
 
 #include <QAbstractSpinBox>
 
@@ -57,5 +56,3 @@ class SpinBox : public QAbstractSpinBox {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // UI_SPINBOX_H

--- a/include/ui/spinboxvalidator.h
+++ b/include/ui/spinboxvalidator.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef UI_VALIDATOR_H
-#define UI_VALIDATOR_H
+#pragma once
 
 #include <QValidator>
 
@@ -46,5 +45,3 @@ class SpinBoxValidator : public QValidator {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif // UI_VALIDATOR_H

--- a/include/ui/subchunkfileblobitem.h
+++ b/include/ui/subchunkfileblobitem.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef SUBCHUNKFILEBLOBITEM_H
-#define SUBCHUNKFILEBLOBITEM_H
+#pragma once
 
 #include <QList>
 #include <QObject>
@@ -50,5 +49,3 @@ class SubchunkFileBlobItem : public FileBlobItem {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif  // SUBCHUNKFILEBLOBITEM_H

--- a/include/ui/veles_mainwindow.h
+++ b/include/ui/veles_mainwindow.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_MAINWINDOW_H
-#define VELES_MAINWINDOW_H
+#pragma once
 
 #include <QDropEvent>
 #include <QDockWidget>
@@ -102,5 +101,3 @@ class VelesMainWindow : public MainWindowWithDetachableDockWidgets {
 
 }  // namespace ui
 }  // namespace veles
-
-#endif

--- a/include/util/concurrency/threadpool.h
+++ b/include/util/concurrency/threadpool.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_CONCURRENCY_THREADPOOL_H
-#define VELES_UTIL_CONCURRENCY_THREADPOOL_H
+#pragma once
 
 #include <string>
 #include <functional>
@@ -60,5 +59,3 @@ SchedulingResult runTask(const std::string& topic, Task t);
 }  // namespace threadpool
 }  // namespace util
 }  // namespace veles
-
-#endif

--- a/include/util/encoders/base64_encoder.h
+++ b/include/util/encoders/base64_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_BASE64_ENCODER_H
-#define VELES_UTIL_ENCODERS_BASE64_ENCODER_H
+#pragma once
 
 #include "util/encoders/idecoder.h"
 #include "util/encoders/iencoder.h"
@@ -38,5 +37,3 @@ class Base64Encoder : public IEncoder, public IDecoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_BASE64_ENCODER_H

--- a/include/util/encoders/c_data_encoder.h
+++ b/include/util/encoders/c_data_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_C_DATA_ENCODER_H
-#define VELES_UTIL_ENCODERS_C_DATA_ENCODER_H
+#pragma once
 
 #include "util/encoders/iencoder.h"
 
@@ -36,5 +35,3 @@ class CDataEncoder : public IEncoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_C_DATA_ENCODER_H

--- a/include/util/encoders/c_string_encoder.h
+++ b/include/util/encoders/c_string_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_CSTRING_ENCODER_H
-#define VELES_UTIL_ENCODERS_CSTRING_ENCODER_H
+#pragma once
 
 #include "util/encoders/iencoder.h"
 
@@ -35,5 +34,3 @@ class CStringEncoder : public IEncoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_CSTRING_ENCODER_H

--- a/include/util/encoders/factory.h
+++ b/include/util/encoders/factory.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_FACTORY_H
-#define VELES_UTIL_ENCODERS_FACTORY_H
+#pragma once
 
 #include "util/encoders/iencoder.h"
 
@@ -35,5 +34,3 @@ class EncodersFactory {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_FACTORY_H

--- a/include/util/encoders/hex_encoder.h
+++ b/include/util/encoders/hex_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_HEX_ENCODER_H
-#define VELES_UTIL_ENCODERS_HEX_ENCODER_H
+#pragma once
 
 #include "util/encoders/idecoder.h"
 #include "util/encoders/iencoder.h"
@@ -38,5 +37,3 @@ class HexEncoder : public IEncoder, public IDecoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_HEX_ENCODER_H

--- a/include/util/encoders/idecoder.h
+++ b/include/util/encoders/idecoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_IENCODER_IDECODER_H
-#define VELES_UTIL_IENCODER_IDECODER_H
+#pragma once
 
 #include <QByteArray>
 #include <QString>
@@ -34,5 +33,3 @@ class IDecoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_IDECODER_IENCODER_H

--- a/include/util/encoders/iencoder.h
+++ b/include/util/encoders/iencoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_IENCODER_IENCODER_H
-#define VELES_UTIL_IENCODER_IENCODER_H
+#pragma once
 
 #include <QByteArray>
 #include <QString>
@@ -34,5 +33,3 @@ class IEncoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_IENCODER_IENCODER_H

--- a/include/util/encoders/text_encoder.h
+++ b/include/util/encoders/text_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_TEXT_ENCODER_H
-#define VELES_UTIL_ENCODERS_TEXT_ENCODER_H
+#pragma once
 
 #include "util/encoders/idecoder.h"
 #include "util/encoders/iencoder.h"
@@ -41,5 +40,3 @@ class TextEncoder : public IEncoder, public IDecoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_TEXT_ENCODER_H

--- a/include/util/encoders/url_encoder.h
+++ b/include/util/encoders/url_encoder.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_ENCODERS_URL_ENCODER_H
-#define VELES_UTIL_ENCODERS_URL_ENCODER_H
+#pragma once
 
 #include "util/encoders/idecoder.h"
 #include "util/encoders/iencoder.h"
@@ -38,5 +37,3 @@ class UrlEncoder : public IEncoder, public IDecoder {
 }  // namespace encoders
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_ENCODERS_URL_ENCODER_H

--- a/include/util/icons.h
+++ b/include/util/icons.h
@@ -14,12 +14,10 @@
  * limitations under the License.
  *
  */
+#pragma once
 
 #include <QIcon>
 #include <QColor>
-
-#ifndef VELES_UTIL_ICONS_H
-#define VELES_UTIL_ICONS_H
 
 namespace veles {
 namespace util {
@@ -30,5 +28,3 @@ QIcon getColoredIcon(QString path, QColor color, bool black_only = true);
 
 }  // namespace util
 }  // namespace veles
-
-#endif

--- a/include/util/math.h
+++ b/include/util/math.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_MATH_H
-#define VELES_UTIL_MATH_H
+#pragma once
 
 #include <type_traits>
 
@@ -37,5 +36,3 @@ typename std::common_type<T1, T2>::type gcd(T1 a, T2 b) {
 }  // namespace math
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_MATH_H

--- a/include/util/sampling/fake_sampler.h
+++ b/include/util/sampling/fake_sampler.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef FAKE_SAMPLER_H
-#define FAKE_SAMPLER_H
+#pragma once
 
 #include "util/sampling/isampler.h"
 
@@ -40,5 +39,3 @@ class FakeSampler : public ISampler {
 
 }  // namespace util
 }  // namespace veles
-
-#endif

--- a/include/util/sampling/isampler.h
+++ b/include/util/sampling/isampler.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef ISAMPLER_H
-#define ISAMPLER_H
+#pragma once
 
 #include <atomic>
 #include <functional>
@@ -362,5 +361,3 @@ class ISampler {
 
 }  // namespace util
 }  // namespace veles
-
-#endif

--- a/include/util/sampling/uniform_sampler.h
+++ b/include/util/sampling/uniform_sampler.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef UNIFORM_SAMPLER_H
-#define UNIFORM_SAMPLER_H
+#pragma once
 
 #include <vector>
 #include "util/sampling/isampler.h"
@@ -55,5 +54,3 @@ class UniformSampler : public ISampler {
 
 }  // namespace util
 }  // namespace veles
-
-#endif

--- a/include/util/settings/connection_client.h
+++ b/include/util/settings/connection_client.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_SETTINGS_CONNECTION_H
-#define VELES_UTIL_SETTINGS_CONNECTION_H
+#pragma once
 
 #include <QString>
 
@@ -59,10 +58,8 @@ void setServerScript(QString server_script);
 bool shutDownServerOnQuitDefault();
 bool shutDownServerOnQuit();
 void setShutDownServerOnQuit(bool shut_down_server);
+
 }  // namespace connection
 }  // namespace settings
 }  // namespace util
 }  // namespace veles
-
-
-#endif //VELES_UTIL_SETTINGS_CONNECTION_H

--- a/include/util/settings/hexedit.h
+++ b/include/util/settings/hexedit.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_SETTINGS_HEXEDIT_H
-#define VELES_UTIL_SETTINGS_HEXEDIT_H
+#pragma once
 
 namespace veles {
 namespace util {
@@ -31,6 +30,3 @@ void setResizeColumnsToWindowWidth(bool on);
 }  // namespace settings
 }  // namespace util
 }  // namespace veles
-
-
-#endif

--- a/include/util/settings/theme.h
+++ b/include/util/settings/theme.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef THEME_H
-#define THEME_H
+#pragma once
 
 #include <QColor>
 #include <QPalette>
@@ -41,6 +40,3 @@ QFont font();
 }  // namespace settings
 }  // namespace util
 }  // namespace veles
-
-
-#endif

--- a/include/util/string_utils.h
+++ b/include/util/string_utils.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_UTIL_STRINGUTILS_H
-#define VELES_UTIL_STRINGUTILS_H
+#pragma once
+
 #include <functional>
 #include <QChar>
 #include <QString>
@@ -33,5 +33,3 @@ QString stripSpaces(QString src);
 }  // namespace string
 }  // namespace util
 }  // namespace veles
-
-#endif  // VELES_UTIL_STRINGUTILS_H

--- a/include/visualization/base.h
+++ b/include/visualization/base.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_BASE_H
-#define VELES_VISUALIZATION_BASE_H
+#pragma once
 
 #include <QString>
 #include <QBoxLayout>
@@ -96,5 +95,3 @@ class VisualizationWidget : public QOpenGLWidget,
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif  // VELES_VISUALIZATION_BASE_H

--- a/include/visualization/digram.h
+++ b/include/visualization/digram.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef DIGRAM_H
-#define DIGRAM_H
+#pragma once
 
 #include "visualization/digram.h"
 
@@ -65,5 +64,3 @@ class DigramWidget : public VisualizationWidget {
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif

--- a/include/visualization/manipulator.h
+++ b/include/visualization/manipulator.h
@@ -14,9 +14,7 @@
  * limitations under the License.
  *
  */
-
-#ifndef VELES_VISUALIZATION_MANIPULATOR_H
-#define VELES_VISUALIZATION_MANIPULATOR_H
+#pragma once
 
 #include <QObject>
 #include <QQuaternion>
@@ -143,5 +141,3 @@ class SpinManipulator : public Manipulator {
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif  // VELES_VISUALIZATION_MANIPULATOR_H

--- a/include/visualization/minimap.h
+++ b/include/visualization/minimap.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_MINIMAP_H
-#define VELES_VISUALIZATION_MINIMAP_H
+#pragma once
 
 #include <QOpenGLWidget>
 #include <QOpenGLFunctions_3_2_Core>
@@ -159,5 +158,3 @@ class VisualizationMinimap : public QOpenGLWidget,
 
 }  //  namespace visualization
 }  //  namespace veles
-
-#endif  // VELES_VISUALIZATION_MINIMAP_H

--- a/include/visualization/minimap_panel.h
+++ b/include/visualization/minimap_panel.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_MINIMAP_PANEL_H
-#define VELES_VISUALIZATION_MINIMAP_PANEL_H
+#pragma once
 
 #include <QBoxLayout>
 #include <QPair>
@@ -73,5 +72,3 @@ class MinimapPanel : public QWidget {
 
 }  //  namespace visualization
 }  //  namespace veles
-
-#endif  // VELES_VISUALIZATION_MINIMAP_PANEL_H

--- a/include/visualization/panel.h
+++ b/include/visualization/panel.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_PANEL_H
-#define VELES_VISUALIZATION_PANEL_H
+#pragma once
 
 #include <QWidget>
 #include <QBoxLayout>
@@ -114,5 +113,3 @@ class VisualizationPanel : public ui::View {
 
 }  //  namespace visualization
 }  //  namespace veles
-
-#endif  //  VELES_VISUALIZATION_PANEL_H

--- a/include/visualization/samplingmethoddialog.h
+++ b/include/visualization/samplingmethoddialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_SAMPLINGMETHODDIALOG_H
-#define VELES_VISUALIZATION_SAMPLINGMETHODDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QString>
@@ -50,5 +49,3 @@ class SamplingMethodDialog : public QDialog {
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif // VELES_VISUALIZATION_SAMPLINGMETHODDIALOG_H

--- a/include/visualization/selectrangedialog.h
+++ b/include/visualization/selectrangedialog.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_SELECTRANGEDIALOG_H
-#define VELES_VISUALIZATION_SELECTRANGEDIALOG_H
+#pragma once
 
 #include <QDialog>
 #include <QString>
@@ -54,5 +53,3 @@ class SelectRangeDialog : public QDialog {
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif

--- a/include/visualization/trigram.h
+++ b/include/visualization/trigram.h
@@ -14,8 +14,7 @@
  * limitations under the License.
  *
  */
-#ifndef VELES_VISUALIZATION_TRIGRAM_H
-#define VELES_VISUALIZATION_TRIGRAM_H
+#pragma once
 
 #include "visualization/trigram.h"
 
@@ -216,5 +215,3 @@ class TrigramWidget : public VisualizationWidget {
 
 }  // namespace visualization
 }  // namespace veles
-
-#endif  // VELES_VISUALIZATION_TRIGRAM_H

--- a/test/util/sampling/mock_sampler.h
+++ b/test/util/sampling/mock_sampler.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+#pragma once
 
 #include <QByteArray>
 #include "gmock/gmock.h"


### PR DESCRIPTION
Removed header guards and switched to `#pragma once`.

Reasons behind this decision:
- Manually created and not verified header guards are very error prone.
- We already have many errors in the headers, e.g.:
  - https://github.com/codilime/veles/blob/ff8acfd132e3891ffc23fe4e65e19e926ebe3268/include/data/nodeid.h
  - https://github.com/codilime/veles/blob/ff8acfd132e3891ffc23fe4e65e19e926ebe3268/include/network/msgpackwrapper.h
  - https://github.com/codilime/veles/blob/ff8acfd132e3891ffc23fe4e65e19e926ebe3268/include/dbif/error.h (lacking _H)
- It seems that we won't have any automatic verification of them in near future.
- We don't have any crazy symlinks in the repo, so we probably don't need to be concerned about `#pragma once`-specific problems.