### PR TITLE
Fix most issues with reordering tabs in QTabBar

### DIFF
--- a/src/ui/dockwidget.cc
+++ b/src/ui/dockwidget.cc
@@ -1027,10 +1027,12 @@ void MainWindowWithDetachableDockWidgets::hideAllRubberBands() {
 
 void MainWindowWithDetachableDockWidgets::setActiveDockWidget(
     DockWidget* dock_widget) {
-  active_dock_widget_ = dock_widget;
+  if (active_dock_widget_ != dock_widget) {
+    active_dock_widget_ = dock_widget;
 
-  for (auto window : main_windows_) {
-    window->updateDocksAndTabs();
+    for (auto window : main_windows_) {
+      window->updateDocksAndTabs();
+    }
   }
 }
 

--- a/src/ui/dockwidget.cc
+++ b/src/ui/dockwidget.cc
@@ -1027,6 +1027,10 @@ void MainWindowWithDetachableDockWidgets::hideAllRubberBands() {
 
 void MainWindowWithDetachableDockWidgets::setActiveDockWidget(
     DockWidget* dock_widget) {
+  // TODO more in depth look into active dock marking
+  // In theory this condition can cause some degradation in drawing which dock is active,
+  // but currently it isn't working correctly despite it, and this condition
+  // fixes some more severe problems.
   if (active_dock_widget_ != dock_widget) {
     active_dock_widget_ = dock_widget;
 


### PR DESCRIPTION
This should fix tabs blinking and severly reduces chances that it
crashes inside QTabBar with wrong internal indexes