### PR TITLE
Add keyboard shortcuts editor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(veles_base
     ${INCLUDE_DIR}/util/sampling/fake_sampler.h
     ${INCLUDE_DIR}/util/settings/connection_client.h
     ${INCLUDE_DIR}/util/settings/hexedit.h
+    ${INCLUDE_DIR}/util/settings/shortcuts.h
     ${INCLUDE_DIR}/util/settings/theme.h
     ${INCLUDE_DIR}/util/settings/visualization.h
 
@@ -98,6 +99,7 @@ add_library(veles_base
     ${SRC_DIR}/util/sampling/fake_sampler.cc
     ${SRC_DIR}/util/settings/connection_client.cc
     ${SRC_DIR}/util/settings/hexedit.cc
+    ${SRC_DIR}/util/settings/shortcuts.cc
     ${SRC_DIR}/util/settings/theme.cc
     ${SRC_DIR}/util/settings/visualization.cc
 
@@ -308,15 +310,17 @@ target_link_libraries(unpyc veles_db parser veles_network)
 # Resources
 qt5_add_resources(RESOURCES resources/veles.qrc)
 qt5_wrap_ui(FORMS
-    ${SRC_DIR}/ui/optionsdialog.ui
-    ${SRC_DIR}/ui/searchdialog.ui
-    ${SRC_DIR}/ui/gotoaddressdialog.ui
-    ${SRC_DIR}/ui/createchunkdialog.ui
-    ${SRC_DIR}/ui/databaseinfo.ui
-    ${SRC_DIR}/ui/logwidget.ui
-    ${SRC_DIR}/ui/connectiondialog.ui
-    ${SRC_DIR}/ui/connectionnotificationwidget.ui
-    )
+  ${SRC_DIR}/ui/connectiondialog.ui
+  ${SRC_DIR}/ui/connectionnotificationwidget.ui
+  ${SRC_DIR}/ui/createchunkdialog.ui
+  ${SRC_DIR}/ui/databaseinfo.ui
+  ${SRC_DIR}/ui/gotoaddressdialog.ui
+  ${SRC_DIR}/ui/logwidget.ui
+  ${SRC_DIR}/ui/optionsdialog.ui
+  ${SRC_DIR}/ui/searchdialog.ui
+  ${SRC_DIR}/ui/shortcutselection.ui
+  ${SRC_DIR}/ui/shortcutssettings.ui
+)
 
 if(WIN32)
   set(ICONS ${CMAKE_SOURCE_DIR}/resources/icons/veles.rc)
@@ -360,6 +364,8 @@ add_executable(main_ui
     ${INCLUDE_DIR}/ui/spinbox.h
     ${INCLUDE_DIR}/ui/spinboxvalidator.h
     ${INCLUDE_DIR}/ui/connectiondialog.h
+    ${INCLUDE_DIR}/ui/shortcutedit.h
+    ${INCLUDE_DIR}/ui/shortcutssettings.h
     ${SRC_DIR}/ui/main.cc
     ${SRC_DIR}/ui/logwidget.cc
     ${SRC_DIR}/ui/veles_mainwindow.cc
@@ -382,6 +388,8 @@ add_executable(main_ui
     ${SRC_DIR}/ui/spinbox.cc
     ${SRC_DIR}/ui/spinboxvalidator.cc
     ${SRC_DIR}/ui/connectiondialog.cc
+    ${SRC_DIR}/ui/shortcutedit.cc
+    ${SRC_DIR}/ui/shortcutssettings.cc
     ${RESOURCES}
     ${VISUALIZATION_SHADERS}
     ${FORMS}

--- a/include/ui/hexedit.h
+++ b/include/ui/hexedit.h
@@ -169,7 +169,6 @@ public slots:
                   bool doted = false);
 
   void setSelectedChunk(QModelIndex newSelectedChunk);
-  void copyToClipboard(util::encoders::IEncoder *enc = nullptr);
   bool isRangeVisible(qint64 start, qint64 size);
   bool isByteVisible(qint64 bytePos);
   void setSelectionEnd(qint64 bytePos);
@@ -177,6 +176,9 @@ public slots:
   void scrollToCurrentChunk();
   void parse(QAction *action);
   void resetCursor();
+
+ private slots:
+  void copyToClipboard(util::encoders::IEncoder *enc = nullptr);
 };
 
 }  // namespace ui

--- a/include/ui/hexeditwidget.h
+++ b/include/ui/hexeditwidget.h
@@ -49,8 +49,11 @@ class HexEditWidget : public View {
   void reapplySettings() override;
   void setParserIds(QStringList ids);
   QString addressAsText(qint64 addr);
-  QAction* findAction() {return find_act_;};
-  QAction* findNextAction() {return find_next_act_;};
+  QAction* findAction() {return find_act_;}
+  QAction* findNextAction() {return find_next_act_;}
+  QAction* showVisualizationAction() {return visualization_act_;}
+  QAction* showHexEditAction() {return show_hex_edit_act_;}
+  QAction* showNodeTreeAction() {return show_node_tree_act_;}
 
  signals:
   void showNodeTree(bool show);

--- a/include/ui/shortcutedit.h
+++ b/include/ui/shortcutedit.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include <QLineEdit>
+
+namespace veles {
+namespace ui {
+
+// QKeySequenceEdit doesn't play nice with AltGr key so we need to use our own
+// custom widget
+class ShortcutEdit : public QLineEdit {
+  Q_OBJECT
+
+ signals:
+  void escapePressed();
+
+ public:
+  using QLineEdit::QLineEdit;
+  Qt::Key key() const;
+  void reset();
+
+ protected:
+  void keyPressEvent(QKeyEvent* event) override;
+
+ private:
+  Qt::Key key_;
+};
+
+}  // namespace ui
+}  // namespace veles

--- a/include/ui/shortcutssettings.h
+++ b/include/ui/shortcutssettings.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include <QSortFilterProxyModel>
+
+#include "ui_shortcutselection.h"
+#include "ui_shortcutssettings.h"
+#include "util/settings/shortcuts.h"
+
+namespace veles {
+namespace ui {
+
+class ShortcutsFilter : public QSortFilterProxyModel {
+  using QSortFilterProxyModel::QSortFilterProxyModel;
+
+protected:
+  virtual bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+};
+
+class ShortcutEditDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit ShortcutEditDialog(QWidget* parent = 0);
+  ~ShortcutEditDialog();
+  void reset();
+  QKeySequence getSequence() const;
+
+ protected:
+  virtual void showEvent(QShowEvent *event) override;
+
+ private:
+  Ui::ShortcutEditDialog* ui;
+
+ private slots:
+  void checkConflicts();
+};
+
+class ShortcutsDialog : public QDialog {
+  Q_OBJECT
+
+ public:
+  explicit ShortcutsDialog(QWidget* parent = 0);
+  ~ShortcutsDialog();
+
+ public slots:
+  void onContextMenu(const QPoint& point);
+
+ protected:
+  virtual void showEvent(QShowEvent* event) override;
+
+ private:
+  Ui::ShortcutsDialog* ui_;
+  QMenu* context_menu_;
+  ShortcutEditDialog* shortcut_selection_;
+  QSet<util::settings::shortcuts::ShortcutType> modified_types_;
+  util::settings::shortcuts::ShortcutsModel* model_;
+  ShortcutsFilter* filter_;
+
+  void showShortcutSelectionDialog(const QModelIndex& index);
+
+ private slots:
+  void showShortcutSelectionDialog(util::settings::shortcuts::ShortcutType type);
+};
+
+}  // namespace ui
+}  // namespace veles

--- a/include/ui/veles_mainwindow.h
+++ b/include/ui/veles_mainwindow.h
@@ -32,6 +32,7 @@
 
 #include "ui/dockwidget.h"
 #include "ui/optionsdialog.h"
+#include "ui/shortcutssettings.h"
 #include "ui/connectiondialog.h"
 #include "ui/connectionmanager.h"
 
@@ -85,6 +86,7 @@ class VelesMainWindow : public MainWindowWithDetachableDockWidgets {
   QAction *open_act_;
   QAction *exit_act_;
   QAction *options_act_;
+  QAction *shortcuts_act_;
 
   QAction *about_act_;
   QAction *about_qt_act_;
@@ -94,6 +96,7 @@ class VelesMainWindow : public MainWindowWithDetachableDockWidgets {
 
   dbif::ObjectHandle database_;
   OptionsDialog *options_dialog_;
+  ShortcutsDialog *shortcuts_dialog_;
 
   QStringList parsers_list_;
 

--- a/include/util/settings/shortcuts.h
+++ b/include/util/settings/shortcuts.h
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#pragma once
+
+#include <QAbstractItemModel>
+#include <QAction>
+#include <QDataStream>
+#include <QDialog>
+#include <QKeySequence>
+#include <QMenu>
+#include <QMetaType>
+#include <QPointer>
+#include <QString>
+
+namespace veles {
+namespace util {
+namespace settings {
+namespace shortcuts {
+
+enum ShortcutType : uint32_t {
+  UNKNOWN_SHORTCUT = 0,
+  EXIT_APPLICATION = 1,
+  OPEN_FILE = 2,
+  NEW_FILE = 3,
+  SHOW_DATABASE = 4,
+  SHOW_LOG = 5,
+  SHOW_ABOUT = 6,
+  SHOW_ABOUT_QT = 7,
+  SHOW_OPTIONS = 8,
+  SHOW_SHORTCUT_OPTIONS = 9,
+  SHOW_CONNECT_DIALOG = 10,
+  DISCONNECT_FROM_SERVER = 11,
+  KILL_LOCAL_SERVER = 12,
+  DOCK_MOVE_TO_TOP = 13,
+  DOCK_MOVE_TO_TOP_MAX = 14,
+  DOCK_SPLIT_HORIZ = 15,
+  DOCK_SPLIT_VERT = 16,
+  CREATE_CHUNK = 17,
+  CREATE_CHILD_CHUNK = 18,
+  GO_TO_ADDRESS = 19,
+  REMOVE_CHUNK = 20,
+  SAVE_SELECTION_TO_FILE = 21,
+  HEX_FIND = 22,
+  HEX_FIND_NEXT = 23,
+  OPEN_VISUALIZATION = 24,
+  OPEN_HEX = 25,
+  SHOW_NODE_TREE = 26,
+  SHOW_MINIMAP = 27,
+  VISUALIZATION_DIGRAM = 28,
+  VISUALIZATION_TRIGRAM = 29,
+  VISUALIZATION_LAYERED_DIGRAM = 30,
+  VISUALIZATION_OPTIONS = 31,
+  TRIGRAM_CUBE = 32,
+  TRIGRAM_CYLINDER = 33,
+  TRIGRAM_SPHERE = 34,
+  VISUALIZATION_MANIPULATOR_SPIN = 35,
+  VISUALIZATION_MANIPULATOR_TRACKBALL = 36,
+  VISUALIZATION_MANIPULATOR_FREE = 37,
+  COPY = 38,
+};
+
+QMap<ShortcutType, QList<QKeySequence>> defaultShortcuts();
+QList<QKeySequence> getShortcuts(ShortcutType type);
+void setShortcuts(ShortcutType type, const QList<QKeySequence>& shortcuts);
+
+class ShortcutsItem {
+ public:
+  explicit ShortcutsItem(const QString& display_name = QString(""), ShortcutsItem* parent = 0);
+  ShortcutsItem(const QString& display_name, ShortcutsItem* parent, util::settings::shortcuts::ShortcutType type);
+  ShortcutsItem(const QString& name, const QString& display_name, ShortcutsItem* parent, util::settings::shortcuts::ShortcutType type);
+  ~ShortcutsItem();
+
+  QAction* createQAction(QObject* parent, Qt::ShortcutContext context = Qt::WindowShortcut);
+  QAction* createQAction(QObject* parent, QIcon icon, Qt::ShortcutContext context = Qt::WindowShortcut);
+  QString name() const;
+  QString displayName() const;
+  ShortcutsItem* parent() const;
+  QList<QKeySequence> shortcuts() const;
+  QString displayShortcuts() const;
+  bool deleteShortcut(const QKeySequence& shortcut);
+  bool addShortcut(const QKeySequence& shortcut);
+  void setConflict(bool conflict);
+  bool hasConflict() const;
+  util::settings::shortcuts::ShortcutType type() const;
+  void updateShortcutsForActions();
+  bool isCategory() const;
+
+  QList<ShortcutsItem*> children;
+
+ private:
+  QList<QPointer<QAction>> actions_;
+  QList<QKeySequence> shortcuts_;
+  QString display_shortcuts_;
+  QString name_;
+  QString display_name_;
+  ShortcutsItem* parent_;
+  bool conflict_;
+  util::settings::shortcuts::ShortcutType type_;
+  bool is_category_;
+};
+
+class ShortcutsModel : public QAbstractItemModel {
+ public:
+  static const int COLUMN_INDEX_NAME = 0;
+  static const int COLUMN_INDEX_SHORTCUTS = 1;
+  static const int CATEGORY_ROLE = Qt::UserRole;
+  static const int TYPE_ROLE = Qt::UserRole + 1;
+  static const int SHORTCUTS_ROLE = Qt::UserRole + 2;
+
+  ~ShortcutsModel();
+
+  virtual QModelIndex index(int row, int column, const QModelIndex& parent = QModelIndex()) const override;
+  virtual QModelIndex parent(const QModelIndex& index) const override;
+  virtual int rowCount(const QModelIndex& parent = QModelIndex()) const override;
+  virtual int columnCount(const QModelIndex& parent = QModelIndex()) const override;
+  virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+  QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+  static ShortcutsModel* getShortcutsModel();
+  QAction* createQAction(util::settings::shortcuts::ShortcutType type, QObject* parent, Qt::ShortcutContext context = Qt::WindowShortcut);
+  QAction* createQAction(util::settings::shortcuts::ShortcutType type, QObject* parent, QIcon icon, Qt::ShortcutContext context = Qt::WindowShortcut);
+  void addShortcut(util::settings::shortcuts::ShortcutType type, const QKeySequence& shortcut);
+  void removeShortcut(util::settings::shortcuts::ShortcutType type, const QKeySequence& shortcut);
+  ShortcutsItem* itemFromIndex(const QModelIndex& index) const;
+  QModelIndex indexFromItem(ShortcutsItem* item) const;
+  QList<ShortcutsItem*> getItemsForSequence(const QKeySequence& sequence);
+  void updateShortcutsForType(util::settings::shortcuts::ShortcutType type);
+  void resetShortcutsForType(util::settings::shortcuts::ShortcutType type);
+  void resetShortcutsToDefault(util::settings::shortcuts::ShortcutType type);
+  void resetAllShortcutsToDefaults();
+  QList<util::settings::shortcuts::ShortcutType> validShortcutTypes() const;
+
+ private:
+  ShortcutsModel();
+
+  ShortcutsItem* addCategory(const QString& name, ShortcutsItem* parent);
+  ShortcutsItem* addShortcutType(util::settings::shortcuts::ShortcutType type, ShortcutsItem* parent, const QString& name, const QString& display_name = QString(""));
+  bool checkIfConflicts(ShortcutsItem* item) const;
+
+  ShortcutsItem* root_;
+  QMap<util::settings::shortcuts::ShortcutType, ShortcutsItem*> type_to_shortcut_;
+  QMap<QKeySequence, QList<ShortcutsItem*>> sequence_to_shortcut_;
+};
+
+}  // namespace shortcuts
+}  // namespace settings
+}  // namespace util
+}  // namespace veles
+
+Q_DECLARE_METATYPE(veles::util::settings::shortcuts::ShortcutType)

--- a/include/visualization/trigram.h
+++ b/include/visualization/trigram.h
@@ -36,6 +36,7 @@
 #include <QToolBar>
 #include <QAction>
 
+#include "util/settings/shortcuts.h"
 #include "visualization/base.h"
 #include "visualization/manipulator.h"
 
@@ -147,8 +148,7 @@ class TrigramWidget : public VisualizationWidget {
   void initTextures();
   void initGeometry();
 
-  QAction* createAction(const QIcon& icon, Manipulator* manipulator,
-      const QList<QKeySequence>& sequences);
+  QAction* createAction(util::settings::shortcuts::ShortcutType type, const QIcon& icon, Manipulator* manipulator);
   QAbstractButton* createActionButton(QAction* action);
   virtual void prepareManipulatorToolbar(QMainWindow* visualization_window);
 

--- a/src/ui/connectionmanager.cc
+++ b/src/ui/connectionmanager.cc
@@ -23,9 +23,12 @@
 #include "ui/connectionmanager.h"
 #include "util/version.h"
 #include "util/settings/connection_client.h"
+#include "util/settings/shortcuts.h"
 
 namespace veles {
 namespace ui {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 /*****************************************************************************/
 /* ConnectionManager */
@@ -35,10 +38,12 @@ ConnectionManager::ConnectionManager(QWidget* parent)
     : QObject(parent), server_process_(nullptr),
     network_client_output_(nullptr) {
   connection_dialog_ = new ConnectionDialog(parent);
-  show_connection_dialog_action_ = new QAction("Connect...", this);
-  disconnect_action_ = new QAction("Disconnect", this);
-  kill_locally_created_server_action_ = new QAction(
-      "Kill locally created server", this);
+  show_connection_dialog_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+      util::settings::shortcuts::SHOW_CONNECT_DIALOG, this, Qt::ApplicationShortcut);
+  disconnect_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::DISCONNECT_FROM_SERVER, this, Qt::ApplicationShortcut);
+  kill_locally_created_server_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::KILL_LOCAL_SERVER, this, Qt::ApplicationShortcut);
   kill_locally_created_server_action_->setEnabled(false);
   disconnect_action_->setEnabled(false);
 

--- a/src/ui/dockwidget.cc
+++ b/src/ui/dockwidget.cc
@@ -29,9 +29,12 @@
 
 #include "ui/dockwidget.h"
 #include "ui/dockwidget_native.h"
+#include "util/settings/shortcuts.h"
 
 namespace veles {
 namespace ui {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 /*****************************************************************************/
 /* QProxyStyleForDockWidgetWithIconOnTitleBar */
@@ -101,6 +104,7 @@ DockWidget::DockWidget() : QDockWidget(), timer_id_(0), ticks_(0),
   maximize_here_action_ = createMoveToNewWindowAndMaximizeAction();
   addAction(maximize_here_action_);
   detach_action_ = createMoveToNewWindowAction();
+  addAction(detach_action_);
   createSplitActions();
 
   connect(this, SIGNAL(customContextMenuRequested(const QPoint&)),
@@ -354,7 +358,8 @@ QMenu* DockWidget::createMoveToWindowMenu() {
 }
 
 QAction* DockWidget::createMoveToNewWindowAction() {
-  auto action = new QAction(tr("Move to new top level window"), this);
+  auto action = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::DOCK_MOVE_TO_TOP, this, Qt::WidgetWithChildrenShortcut);
   connect(action, SIGNAL(triggered()),
       this, SLOT(detachToNewTopLevelWindow()));
 
@@ -362,10 +367,9 @@ QAction* DockWidget::createMoveToNewWindowAction() {
 }
 
 QAction* DockWidget::createMoveToNewWindowAndMaximizeAction() {
-  auto action = new QAction(tr("Move to new top level window and maximize"), this);
-  action->setShortcut(QKeySequence(Qt::Key_F12));
-  action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-  action->setIcon(QIcon(":/images/maximize.png"));
+  auto action = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::DOCK_MOVE_TO_TOP_MAX, this,
+        QIcon(":/images/maximize.png"), Qt::WidgetWithChildrenShortcut);
   connect(action, SIGNAL(triggered()),
       this, SLOT(detachToNewTopLevelWindowAndMaximize()));
 
@@ -373,21 +377,19 @@ QAction* DockWidget::createMoveToNewWindowAndMaximizeAction() {
 }
 
 void DockWidget::createSplitActions() {
-  split_horizontally_action_ = new QAction(tr("Split horizontally"), this);
-  split_horizontally_action_->setShortcutContext(
-      Qt::WidgetWithChildrenShortcut);
-  split_horizontally_action_->setIcon(
-      QIcon(":/images/split_horizontally.png"));
+  split_horizontally_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::DOCK_SPLIT_HORIZ, this,
+        QIcon(":/images/split_horizontally.png"), Qt::WidgetWithChildrenShortcut);
   connect(split_horizontally_action_, SIGNAL(triggered()), this,
       SLOT(splitHorizontally()));
+  addAction(split_horizontally_action_);
 
-  split_vertically_action_ = new QAction(tr("Split vertically"), this);
-  split_vertically_action_->setShortcutContext(
-      Qt::WidgetWithChildrenShortcut);
-  split_vertically_action_->setIcon(
-      QIcon(":/images/split_vertically.png"));
+  split_vertically_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::DOCK_SPLIT_VERT, this,
+        QIcon(":/images/split_vertically.png"), Qt::WidgetWithChildrenShortcut);
   connect(split_vertically_action_, SIGNAL(triggered()), this,
       SLOT(splitVertically()));
+  addAction(split_vertically_action_);
 }
 
 /*****************************************************************************/

--- a/src/ui/hexeditwidget.cc
+++ b/src/ui/hexeditwidget.cc
@@ -37,6 +37,7 @@
 #include "ui/veles_mainwindow.h"
 
 #include "util/settings/hexedit.h"
+#include "util/settings/shortcuts.h"
 #include "util/settings/theme.h"
 #include "util/icons.h"
 
@@ -44,6 +45,8 @@
 
 namespace veles {
 namespace ui {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 /*****************************************************************************/
 /* Public methods */
@@ -98,44 +101,43 @@ QString HexEditWidget::addressAsText(qint64 addr) {
 /*****************************************************************************/
 
 void HexEditWidget::createActions() {
-  upload_act_ = new QAction(QIcon(":/images/upload-32.ico"), tr("&Upload"),
-      this);
-  upload_act_->setShortcuts(QKeySequence::Save);
-  upload_act_->setStatusTip(tr("Upload changed to database"));
-  connect(upload_act_, SIGNAL(triggered()), this, SLOT(uploadChanges()));
-  upload_act_->setEnabled(false);
+//  Currently not implemented
+//  upload_act_ = new QAction(QIcon(":/images/upload-32.ico"), tr("&Upload"),
+//      this);
+//  upload_act_->setShortcuts(QKeySequence::Save);
+//  upload_act_->setStatusTip(tr("Upload changed to database"));
+//  connect(upload_act_, SIGNAL(triggered()), this, SLOT(uploadChanges()));
+//  upload_act_->setEnabled(false);
 
-  save_as_act_ = new QAction(QIcon(":/images/save.png"), tr("Save &As..."),
-      this);
-  save_as_act_->setShortcuts(QKeySequence::SaveAs);
-  save_as_act_->setStatusTip(tr("Save the document under a new name"));
-  connect(save_as_act_, SIGNAL(triggered()), this, SLOT(saveAs()));
-  save_as_act_->setEnabled(false);
+//  save_as_act_ = new QAction(QIcon(":/images/save.png"), tr("Save &As..."),
+//      this);
+//  save_as_act_->setShortcuts(QKeySequence::SaveAs);
+//  save_as_act_->setStatusTip(tr("Save the document under a new name"));
+//  connect(save_as_act_, SIGNAL(triggered()), this, SLOT(saveAs()));
+//  save_as_act_->setEnabled(false);
 
-  save_readable_ = new QAction(tr("Save &Readable..."), this);
-  save_readable_->setStatusTip(tr("Save document in readable form"));
+//  save_readable_ = new QAction(tr("Save &Readable..."), this);
+//  save_readable_->setStatusTip(tr("Save document in readable form"));
   // connect(save_readable_, SIGNAL(triggered()), this,
   // SLOT(saveToReadableFile()));
 
-  undo_act_ = new QAction(QIcon(":/images/undo.png"), tr("&Undo"), this);
-  undo_act_->setShortcuts(QKeySequence::Undo);
-  undo_act_->setEnabled(false);
+//  undo_act_ = new QAction(QIcon(":/images/undo.png"), tr("&Undo"), this);
+//  undo_act_->setShortcuts(QKeySequence::Undo);
+//  undo_act_->setEnabled(false);
 
-  redo_act_ = new QAction(QIcon(":/images/redo.png"), tr("&Redo"), this);
-  redo_act_->setShortcuts(QKeySequence::Redo);
-  redo_act_->setEnabled(false);
+//  redo_act_ = new QAction(QIcon(":/images/redo.png"), tr("&Redo"), this);
+//  redo_act_->setShortcuts(QKeySequence::Redo);
+//  redo_act_->setEnabled(false);
 
-  find_act_ = new QAction(QIcon(":/images/find.png"), tr("&Find/Replace"),
-      this);
-  find_act_->setShortcuts(QKeySequence::Find);
-  find_act_->setShortcutContext(Qt::WidgetWithChildrenShortcut);
-  find_act_->setStatusTip(tr("Show the Dialog for finding and replacing"));
+  find_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::HEX_FIND,
+        this, QIcon(":/images/find.png"), Qt::WidgetWithChildrenShortcut);
+  find_act_->setStatusTip(tr("Show the dialog for finding and replacing"));
   connect(find_act_, SIGNAL(triggered()), this, SLOT(showSearchDialog()));
 
-  find_next_act_ = new QAction(QIcon(":/images/find.png"), tr("Find &next"),
-      this);
-  find_next_act_->setShortcuts(QKeySequence::FindNext);
-  find_next_act_->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+  find_next_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::HEX_FIND_NEXT,
+        this, QIcon(":/images/find.png"), Qt::WidgetWithChildrenShortcut);
   find_next_act_->setStatusTip(
       tr("Find next occurrence of the searched pattern"));
   find_next_act_->setEnabled(false);
@@ -144,16 +146,18 @@ void HexEditWidget::createActions() {
       this, SLOT(enableFindNext(bool)));
 
   QColor icon_color = palette().color(QPalette::WindowText);
-  visualization_act_ = new QAction(
-      util::getColoredIcon(":/images/trigram_icon.png", icon_color),
-      tr("&Visualization"), this);
+  visualization_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::OPEN_VISUALIZATION, this,
+        util::getColoredIcon(":/images/trigram_icon.png", icon_color),
+        Qt::WidgetWithChildrenShortcut);
   visualization_act_->setToolTip(tr("Visualization"));
   visualization_act_->setEnabled(data_model_->binData().size() > 0);
   connect(visualization_act_, SIGNAL(triggered()), this,
           SLOT(showVisualization()));
 
-  show_node_tree_act_ = new QAction(QIcon(":/images/show_node_tree.png"),
-      tr("&Node tree"), this);
+  show_node_tree_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_NODE_TREE,
+        this, QIcon(":/images/show_node_tree.png"), Qt::WidgetWithChildrenShortcut);
   show_node_tree_act_->setToolTip(tr("Node tree"));
   show_node_tree_act_->setEnabled(true);
   show_node_tree_act_->setCheckable(true);
@@ -161,17 +165,20 @@ void HexEditWidget::createActions() {
   connect(show_node_tree_act_, SIGNAL(toggled(bool)),
       this, SIGNAL(showNodeTree(bool)));
 
-  show_minimap_act_ = new QAction(QIcon(":/images/show_minimap.png"),
-      tr("&Minimap"), this);
-  show_minimap_act_->setToolTip(tr("Minimap"));
-  show_minimap_act_->setEnabled(true);
-  show_minimap_act_->setCheckable(true);
-  show_minimap_act_->setChecked(false);
-  connect(show_minimap_act_, SIGNAL(toggled(bool)), this,
-      SIGNAL(showMinimap(bool)));
+//  Currently not implemented
+//  show_minimap_act_ = ShortcutsModel::ShortcutsModel::getShortcutsModel()->createQAction(
+//        util::settings::shortcuts::SHOW_MINIMAP,
+//        this, QIcon(":/images/show_minimap.png"), Qt::WidgetWithChildrenShortcut);
+//  show_minimap_act_->setToolTip(tr("Minimap"));
+//  show_minimap_act_->setEnabled(true);
+//  show_minimap_act_->setCheckable(true);
+//  show_minimap_act_->setChecked(false);
+//  connect(show_minimap_act_, SIGNAL(toggled(bool)), this,
+//      SIGNAL(showMinimap(bool)));
 
-  show_hex_edit_act_ = new QAction(QIcon(":/images/show_hex_edit.png"),
-      tr("Show &hex editor"), this);
+  show_hex_edit_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::OPEN_HEX,
+        this, QIcon(":/images/show_hex_edit.png"), Qt::WidgetWithChildrenShortcut);
   show_hex_edit_act_->setToolTip(tr("Hex editor"));
   show_hex_edit_act_->setEnabled(true);
   connect(show_hex_edit_act_, SIGNAL(triggered()),
@@ -180,8 +187,10 @@ void HexEditWidget::createActions() {
 
 void HexEditWidget::createToolBars() {
   tools_tool_bar_ = new QToolBar(tr("Tools"));
+  addAction(show_node_tree_act_);
   tools_tool_bar_->addAction(show_node_tree_act_);
   //Disabled until minimap does anything of value in hex-view
+  //addAction(show_minimap_act_);
   //tools_tool_bar_->addAction(show_minimap_act_);
 
   auto parser_tool_button = new QToolButton();
@@ -195,6 +204,8 @@ void HexEditWidget::createToolBars() {
   widget_action->setDefaultWidget(parser_tool_button);
   tools_tool_bar_->addAction(widget_action);
 
+  addAction(visualization_act_);
+  addAction(show_hex_edit_act_);
   tools_tool_bar_->addAction(visualization_act_);
   tools_tool_bar_->addAction(show_hex_edit_act_);
   tools_tool_bar_->setContextMenuPolicy(Qt::PreventContextMenu);

--- a/src/ui/nodetreewidget.cc
+++ b/src/ui/nodetreewidget.cc
@@ -39,10 +39,13 @@
 #include "ui/veles_mainwindow.h"
 
 #include "util/settings/hexedit.h"
+#include "util/settings/shortcuts.h"
 #include "util/icons.h"
 
 namespace veles {
 namespace ui {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 /*****************************************************************************/
 /* Public methods */
@@ -99,13 +102,14 @@ void NodeTreeWidget::setParserIds(QStringList ids) {
 /*****************************************************************************/
 
 void NodeTreeWidget::createActions() {
-  undo_act_ = new QAction(QIcon(":/images/undo.png"), tr("&Undo"), this);
-  undo_act_->setShortcuts(QKeySequence::Undo);
-  undo_act_->setEnabled(false);
+//  Not implemented yet.
+//  undo_act_ = new QAction(QIcon(":/images/undo.png"), tr("&Undo"), this);
+//  undo_act_->setShortcuts(QKeySequence::Undo);
+//  undo_act_->setEnabled(false);
 
-  redo_act_ = new QAction(QIcon(":/images/redo.png"), tr("&Redo"), this);
-  redo_act_->setShortcuts(QKeySequence::Redo);
-  redo_act_->setEnabled(false);
+//  redo_act_ = new QAction(QIcon(":/images/redo.png"), tr("&Redo"), this);
+//  redo_act_->setShortcuts(QKeySequence::Redo);
+//  redo_act_->setEnabled(false);
 }
 
 void NodeTreeWidget::createToolBars() {
@@ -126,10 +130,9 @@ void NodeTreeWidget::addChunk(QString name, QString type, QString comment,
 }
 
 void NodeTreeWidget::setupTreeViewHandlers() {
-
-  auto context_menu = new QMenu(tree_view_);
   tree_view_->setContextMenuPolicy(Qt::ActionsContextMenu);
-  remove_action_ = new QAction("remove chunk", context_menu);
+  remove_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::REMOVE_CHUNK, this, Qt::WidgetWithChildrenShortcut);
   tree_view_->addAction(remove_action_);
   remove_action_->setEnabled(false);
 

--- a/src/ui/nodewidget.cc
+++ b/src/ui/nodewidget.cc
@@ -59,6 +59,9 @@ NodeWidget::NodeWidget(MainWindowWithDetachableDockWidgets *main_window,
       main_window, data_model, selection_model);
   addAction(hex_edit_widget_->findAction());
   addAction(hex_edit_widget_->findNextAction());
+  addAction(hex_edit_widget_->showVisualizationAction());
+  addAction(hex_edit_widget_->showHexEditAction());
+  addAction(hex_edit_widget_->showNodeTreeAction());
   setCentralWidget(hex_edit_widget_);
 
   node_tree_dock_ = new QDockWidget;

--- a/src/ui/shortcutedit.cc
+++ b/src/ui/shortcutedit.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ui/shortcutedit.h"
+
+#include <QKeyEvent>
+
+namespace veles {
+namespace ui {
+
+Qt::Key ShortcutEdit::key() const {
+  return key_;
+}
+
+void ShortcutEdit::reset() {
+  key_ = Qt::Key_unknown;
+  clear();
+}
+
+void ShortcutEdit::keyPressEvent(QKeyEvent* event) {
+  int key = event->key();
+  if (key == 0 || key == Qt::Key_unknown) {
+    // Unknown unhandled key pressed
+    return;
+  }
+  if (event->modifiers() != Qt::NoModifier && event->modifiers() != Qt::KeypadModifier) {
+    // Modifier pressed - we can't handle it correctly so we ignore it here
+    // and handle it through checkboxes
+    return;
+  }
+  if (key == Qt::Key_Shift || key == Qt::Key_Control || key == Qt::Key_Meta ||
+      key == Qt::Key_Alt || key == Qt::Key_AltGr) {
+    // Only modifier pressed - it sometimes can be missed by above check (i.e. meta key on Windows)
+    return;
+  }
+  key_ = static_cast<Qt::Key>(key);
+  setText(QKeySequence(key_).toString());
+}
+
+}  // namespace ui
+}  // namespace veles

--- a/src/ui/shortcutselection.ui
+++ b/src/ui/shortcutselection.ui
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShortcutEditDialog</class>
+ <widget class="QDialog" name="ShortcutEditDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>290</width>
+    <height>113</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Add shortcut</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="shiftBox">
+     <property name="text">
+      <string>Shift</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="altBox">
+     <property name="text">
+      <string>Alt</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="ctrlBox">
+     <property name="text">
+      <string>Ctrl</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="veles::ui::ShortcutEdit" name="lineEdit">
+     <property name="contextMenuPolicy">
+      <enum>Qt::NoContextMenu</enum>
+     </property>
+     <property name="placeholderText">
+      <string>Press key without modifiers</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" rowspan="2">
+    <widget class="QLabel" name="conflictLabel">
+     <property name="text">
+      <string>TextLabel</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="metaBox">
+     <property name="text">
+      <string>Meta</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>veles::ui::ShortcutEdit</class>
+   <extends>QLineEdit</extends>
+   <header>ui/shortcutedit.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>lineEdit</tabstop>
+  <tabstop>ctrlBox</tabstop>
+  <tabstop>altBox</tabstop>
+  <tabstop>shiftBox</tabstop>
+  <tabstop>metaBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ShortcutEditDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ShortcutEditDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/shortcutssettings.cc
+++ b/src/ui/shortcutssettings.cc
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include "ui/shortcutssettings.h"
+
+#include <QMessageBox>
+
+#include "util/settings/shortcuts.h"
+
+namespace veles {
+namespace ui {
+
+using namespace util::settings::shortcuts;
+
+ShortcutsDialog::ShortcutsDialog(QWidget* parent) :
+    QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint),
+    ui_(new Ui::ShortcutsDialog), shortcut_selection_(new ShortcutEditDialog(this)),
+    model_(ShortcutsModel::getShortcutsModel()), filter_(new ShortcutsFilter(this)){
+  ui_->setupUi(this);
+  filter_->setSourceModel(model_);
+  ui_->shortcutsTree->setModel(filter_);
+  ui_->shortcutsTree->setContextMenuPolicy(Qt::CustomContextMenu);
+  connect(ui_->shortcutsTree, &QTreeView::customContextMenuRequested, this, &ShortcutsDialog::onContextMenu);
+  context_menu_ = new QMenu(ui_->shortcutsTree);
+  connect(ui_->filter, &QLineEdit::textChanged, [this] (const QString &text) {
+    ui_->shortcutsTree->collapseAll();
+    filter_->setFilterRegExp(QRegExp(text, Qt::CaseInsensitive, QRegExp::FixedString));
+    if (!text.isEmpty()) {
+      ui_->shortcutsTree->expandAll();
+    }
+  });
+  connect(this, &ShortcutsDialog::accepted, [this] () {
+    for(auto modified : modified_types_) {
+      model_->updateShortcutsForType(modified);
+    }
+    modified_types_.clear();
+  });
+  connect(this, &ShortcutsDialog::rejected, [this] () {
+    for(auto modified : modified_types_) {
+      model_->resetShortcutsForType(modified);
+    }
+    modified_types_.clear();
+  });
+  connect(ui_->resetButton, &QPushButton::clicked, [this] () {
+    auto reply = QMessageBox::question(
+          this, "Reset all shortcuts",
+          "Do you wish to reset all shortcuts to their defaults?",
+          QMessageBox::Yes|QMessageBox::No);
+    if (reply == QMessageBox::Yes) {
+      model_->resetAllShortcutsToDefaults();
+      modified_types_ = QSet<util::settings::shortcuts::ShortcutType>::fromList(
+            model_->validShortcutTypes());
+    }
+  });
+  connect(ui_->shortcutsTree, &QTreeView::doubleClicked,
+          this, static_cast<void (ShortcutsDialog::*)(const QModelIndex&)>(
+            &ShortcutsDialog::showShortcutSelectionDialog));
+  QAction* activate = new QAction(ui_->shortcutsTree);
+  activate->setShortcuts({QKeySequence(Qt::Key_Enter), QKeySequence(Qt::Key_Return), QKeySequence(Qt::Key_Space)});
+  activate->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+  connect(activate, &QAction::triggered, [this] () {
+    showShortcutSelectionDialog(ui_->shortcutsTree->currentIndex());
+  });
+  ui_->shortcutsTree->addAction(activate);
+}
+
+ShortcutsDialog::~ShortcutsDialog() {
+  delete ui_;
+}
+
+void ShortcutsDialog::onContextMenu(const QPoint& point) {
+  QModelIndex index = ui_->shortcutsTree->indexAt(point);
+  if (index.isValid()) {
+    auto is_category = index.data(ShortcutsModel::CATEGORY_ROLE).toBool();
+    context_menu_->clear();
+    if (!is_category) {
+      auto add_action = new QAction(tr("Add keyboard shortcut"), context_menu_);
+      context_menu_->addAction(add_action);
+      auto item_type = static_cast<ShortcutType>(
+            index.data(ShortcutsModel::TYPE_ROLE).value<uint32_t>());
+      auto item_shortcuts = index.data(ShortcutsModel::SHORTCUTS_ROLE).value<QList<QKeySequence>>();
+      connect(add_action, &QAction::triggered, [this, item_type] () {
+        showShortcutSelectionDialog(item_type);
+      });
+      auto reset_action = new QAction(tr("Reset shortcut to default"), context_menu_);
+      context_menu_->addAction(reset_action);
+      connect(reset_action, &QAction::triggered, [this, item_type] () {
+        model_->resetShortcutsToDefault(item_type);
+        modified_types_.insert(item_type);
+      });
+      context_menu_->addSeparator();
+      for (const auto& shortcut : item_shortcuts) {
+        auto remove_action = new QAction(tr("Remove %1").arg(shortcut.toString()), context_menu_);
+        connect(remove_action, &QAction::triggered, [this, item_type, shortcut] () {
+          model_->removeShortcut(item_type, shortcut);
+          modified_types_.insert(item_type);
+        });
+        context_menu_->addAction(remove_action);
+      }
+      context_menu_->exec(ui_->shortcutsTree->mapToGlobal(point));
+    }
+  }
+}
+
+void ShortcutsDialog::showEvent(QShowEvent* event) {
+  ui_->shortcutsTree->setColumnWidth(0, ui_->shortcutsTree->width()*2/3);
+  ui_->filter->clear();
+  QDialog::showEvent(event);
+}
+
+void ShortcutsDialog::showShortcutSelectionDialog(ShortcutType type) {
+  shortcut_selection_->reset();
+  connect(shortcut_selection_, &ShortcutEditDialog::accepted, [this, type] () {
+    QKeySequence sequence = shortcut_selection_->getSequence();
+    if (!sequence.isEmpty()) {
+      model_->addShortcut(type, sequence);
+      modified_types_.insert(type);
+    }
+  });
+  shortcut_selection_->exec();
+}
+
+void ShortcutsDialog::showShortcutSelectionDialog(const QModelIndex& index) {
+  if (!index.isValid()) {
+    return;
+  }
+  auto is_category = index.data(ShortcutsModel::CATEGORY_ROLE).toBool();
+  if (is_category) {
+    return;
+  }
+  auto type = static_cast<ShortcutType>(index.data(ShortcutsModel::TYPE_ROLE).value<uint32_t>());
+  showShortcutSelectionDialog(type);
+}
+
+ShortcutEditDialog::ShortcutEditDialog(QWidget* parent) :
+    QDialog(parent, Qt::WindowTitleHint | Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint),
+    ui(new Ui::ShortcutEditDialog) {
+  ui->setupUi(this);
+  ui->conflictLabel->setStyleSheet("QLabel { color : red; }");
+  ui->conflictLabel->setWordWrap(true);
+  connect(ui->lineEdit, &ShortcutEdit::textChanged, this, &ShortcutEditDialog::checkConflicts);
+  connect(ui->altBox, &QCheckBox::stateChanged, this, &ShortcutEditDialog::checkConflicts);
+  connect(ui->ctrlBox, &QCheckBox::stateChanged, this, &ShortcutEditDialog::checkConflicts);
+  connect(ui->shiftBox, &QCheckBox::stateChanged, this, &ShortcutEditDialog::checkConflicts);
+  connect(ui->metaBox, &QCheckBox::stateChanged, this, &ShortcutEditDialog::checkConflicts);
+  auto accept = new QAction(this);
+  accept->setShortcuts({QKeySequence(Qt::CTRL | Qt::Key_Enter), QKeySequence(Qt::CTRL | Qt::Key_Return)});
+  connect(accept, &QAction::triggered, this, &ShortcutEditDialog::accept);
+  addAction(accept);
+  auto reject = new QAction(this);
+  reject->setShortcut(QKeySequence(Qt::SHIFT | Qt::Key_Escape));
+  connect(reject, &QAction::triggered, this, &ShortcutEditDialog::reject);
+  addAction(reject);
+#ifndef Q_OS_MAC
+  ui->metaBox->setVisible(false);
+#endif
+}
+
+ShortcutEditDialog::~ShortcutEditDialog() {
+  delete ui;
+}
+
+void ShortcutEditDialog::reset() {
+  ui->altBox->setChecked(false);
+  ui->ctrlBox->setChecked(false);
+  ui->shiftBox->setChecked(false);
+  ui->metaBox->setChecked(false);
+  ui->lineEdit->reset();
+  ui->conflictLabel->clear();
+  disconnect();
+}
+
+QKeySequence ShortcutEditDialog::getSequence() const {
+  int key = ui->lineEdit->key();
+  if (key == Qt::Key_unknown) {
+    return QKeySequence();
+  }
+  if (ui->altBox->isChecked()) {
+    key |= Qt::ALT;
+  }
+  if (ui->ctrlBox->isChecked()) {
+    key |= Qt::CTRL;
+  }
+  if (ui->shiftBox->isChecked()) {
+    key |= Qt::SHIFT;
+  }
+  if (ui->metaBox->isChecked()) {
+    key |= Qt::META;
+  }
+  return QKeySequence(key);
+}
+
+void ShortcutEditDialog::showEvent(QShowEvent* event) {
+  ui->lineEdit->setFocus();
+}
+
+void ShortcutEditDialog::checkConflicts() {
+  QKeySequence result = getSequence();
+  auto conflicts = ShortcutsModel::getShortcutsModel()->getItemsForSequence(result);
+  if (conflicts.size() != 0) {
+    QStringList conflicts_list;
+    for (auto conflict : conflicts) {
+      conflicts_list.append(conflict->displayName());
+    }
+    ui->conflictLabel->setText(tr("Possible conflicts with : %1.").arg(conflicts_list.join(", ")));
+  } else {
+    ui->conflictLabel->clear();
+  }
+}
+
+bool ShortcutsFilter::filterAcceptsRow(int source_row, const QModelIndex& source_parent) const {
+  auto index = sourceModel()->index(source_row, 0, source_parent);
+  if (index.data(ShortcutsModel::CATEGORY_ROLE).toBool()) {
+    for (int i = 0; i < sourceModel()->rowCount(index); ++i) {
+      if (filterAcceptsRow(i, index)) {
+        return true;
+      }
+    }
+    return false;
+  }
+  return index.data().toString().contains(filterRegExp());
+}
+
+}  // namespace ui
+}  // namespace veles

--- a/src/ui/shortcutssettings.ui
+++ b/src/ui/shortcutssettings.ui
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ShortcutsDialog</class>
+ <widget class="QDialog" name="ShortcutsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>730</width>
+    <height>556</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Keyboard shortcuts</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="filter"/>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Search for commands</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QTreeView" name="shortcutsTree"/>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="resetButton">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ShortcutsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ShortcutsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/veles_mainwindow.cc
+++ b/src/ui/veles_mainwindow.cc
@@ -29,6 +29,7 @@
 #include "dbif/universe.h"
 #include "client/dbif.h"
 #include "util/version.h"
+#include "util/settings/shortcuts.h"
 #include "ui/databaseinfo.h"
 #include "ui/veles_mainwindow.h"
 #include "ui/hexeditwidget.h"
@@ -39,6 +40,8 @@
 
 namespace veles {
 namespace ui {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 /*****************************************************************************/
 /* VelesMainWindow - Public methods */
@@ -154,56 +157,70 @@ void VelesMainWindow::init() {
 
   updateConnectionStatus(
       client::NetworkClient::ConnectionStatus::NotConnected);
+
+  shortcuts_dialog_ = new ShortcutsDialog(this);
 }
 
 void VelesMainWindow::createActions() {
-  new_file_act_ = new QAction(tr("&New..."), this);
-  new_file_act_->setShortcuts(QKeySequence::New);
-  new_file_act_->setStatusTip(tr("Open a new file"));
-  connect(new_file_act_, SIGNAL(triggered()), this, SLOT(newFile()));
+//  new_file_act_ = ShortcutsModel::getShortcutsModel()->createQAction(util::settings::shortcuts::NEW_FILE, this, Qt::ApplicationShortcut);
+//  new_file_act_->setStatusTip(tr("Open a new file"));
+//  connect(new_file_act_, SIGNAL(triggered()), this, SLOT(newFile()));
 
-  open_act_ = new QAction(QIcon(":/images/open.png"), tr("&Open..."), this);
-  open_act_->setShortcuts(QKeySequence::Open);
+  open_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::OPEN_FILE, this, QIcon(":/images/open.png"), Qt::ApplicationShortcut);
   open_act_->setStatusTip(tr("Open an existing file"));
   connect(open_act_, SIGNAL(triggered()), this, SLOT(open()));
 
-  exit_act_ = new QAction(tr("E&xit"), this);
-  exit_act_->setShortcuts(QKeySequence::Quit);
+  exit_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::EXIT_APPLICATION, this, Qt::ApplicationShortcut);
   exit_act_->setStatusTip(tr("Exit the application"));
   connect(exit_act_, SIGNAL(triggered()), qApp, SLOT(closeAllWindows()));
 
-  show_database_act_ = new QAction(tr("Show database view"), this);
+  show_database_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_DATABASE, this, Qt::ApplicationShortcut);
   show_database_act_->setStatusTip(tr("Show database view"));
   connect(show_database_act_, SIGNAL(triggered()), this, SLOT(showDatabase()));
 
-  show_log_act_ = new QAction(tr("Show log"), this);
+  show_log_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_LOG, this, Qt::ApplicationShortcut);
   show_log_act_->setStatusTip(tr("Show log"));
   connect(show_log_act_, SIGNAL(triggered()), this, SLOT(showLog()));
 
-  about_act_ = new QAction(tr("&About"), this);
+  about_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_ABOUT, this, Qt::ApplicationShortcut);
   about_act_->setStatusTip(tr("Show the application's About box"));
   connect(about_act_, SIGNAL(triggered()), this, SLOT(about()));
 
-  about_qt_act_ = new QAction(tr("About &Qt"), this);
+  about_qt_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_ABOUT_QT, this, Qt::ApplicationShortcut);
   about_qt_act_->setStatusTip(tr("Show the Qt library's About box"));
   connect(about_qt_act_, SIGNAL(triggered()), qApp, SLOT(aboutQt()));
 
-  options_act_ = new QAction(tr("&Options"), this);
+  options_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_OPTIONS, this, Qt::ApplicationShortcut);
   options_act_->setStatusTip(
-      tr("Show the Dialog to select applications options"));
+      tr("Show the dialog to select applications options"));
   connect(options_act_, &QAction::triggered, this,
           [this]() { options_dialog_->show(); });
+
+  shortcuts_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_SHORTCUT_OPTIONS, this, Qt::ApplicationShortcut);
+  shortcuts_act_->setStatusTip(
+      tr("Show the dialog to customize keyboard shortcuts"));
+  connect(shortcuts_act_, &QAction::triggered, this,
+          [this]() { shortcuts_dialog_->exec(); });
 }
 
 void VelesMainWindow::createMenus() {
   file_menu_ = menuBar()->addMenu(tr("&File"));
 
   //Not implemented yet.
-  //fileMenu->addAction(newFileAct);
+  //fileMenu->addAction(new_file_act_);
 
   file_menu_->addAction(open_act_);
   file_menu_->addSeparator();
   file_menu_->addAction(options_act_);
+  file_menu_->addAction(shortcuts_act_);
   file_menu_->addSeparator();
   file_menu_->addAction(exit_act_);
 

--- a/src/util/settings/shortcuts.cc
+++ b/src/util/settings/shortcuts.cc
@@ -1,0 +1,479 @@
+/*
+ * Copyright 2017 CodiLime
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+#include "util/settings/shortcuts.h"
+
+#include <assert.h>
+
+#include <QSettings>
+
+#include "util/settings/theme.h"
+
+namespace veles {
+namespace util {
+namespace settings {
+namespace shortcuts {
+
+QList<QKeySequence> getShortcuts(ShortcutType type) {
+  QSettings settings;
+  QSettings::SettingsMap shortcuts = settings.value("keyboard_shortcuts").toMap();
+  if (shortcuts.contains(QString(type))) {
+    // This repacking is done instead of directly getting proper type
+    // from QVariant because it sometimes silently fails on macOS
+    QList<QVariant> var_list = shortcuts.value(QString(type)).toList();
+    QList<QKeySequence> res_list;
+    for (auto var : var_list) {
+      res_list.append(var.value<QKeySequence>());
+    }
+    return res_list;
+  }
+  return defaultShortcuts().value(type);
+}
+
+void setShortcuts(ShortcutType type, const QList<QKeySequence>& shortcuts) {
+  QSettings settings;
+  QSettings::SettingsMap shortcuts_saved = settings.value("keyboard_shortcuts").toMap();
+  QList<QVariant> list;
+  // This repacking is done instead of directly saving the list, because it
+  // sometimes silently fails on macOS
+  for (const auto& shrt : shortcuts) {
+    list.append(QVariant(shrt));
+  }
+  shortcuts_saved[QString(type)] = list;
+  settings.setValue("keyboard_shortcuts", shortcuts_saved);
+}
+
+QMap<ShortcutType, QList<QKeySequence>> defaultShortcuts() {
+  static QMap<ShortcutType, QList<QKeySequence>> defaults;
+  if (defaults.size() == 0) {
+    defaults[EXIT_APPLICATION] = QKeySequence::keyBindings(QKeySequence::Quit);
+    defaults[OPEN_FILE] = QKeySequence::keyBindings(QKeySequence::Open);
+    defaults[NEW_FILE] = QKeySequence::keyBindings(QKeySequence::New);
+    defaults[DOCK_MOVE_TO_TOP_MAX] = {QKeySequence(Qt::Key_F12)};
+    defaults[HEX_FIND] = QKeySequence::keyBindings(QKeySequence::Find);
+    defaults[HEX_FIND_NEXT] = QKeySequence::keyBindings(QKeySequence::FindNext);
+    defaults[VISUALIZATION_MANIPULATOR_SPIN] = {QKeySequence(Qt::CTRL | Qt::Key_1), QKeySequence(Qt::Key_Escape)};
+    defaults[VISUALIZATION_MANIPULATOR_TRACKBALL] = {QKeySequence(Qt::CTRL + Qt::Key_2)};
+    defaults[VISUALIZATION_MANIPULATOR_FREE] = {QKeySequence(Qt::CTRL + Qt::Key_3)};
+    defaults[COPY] = QKeySequence::keyBindings(QKeySequence::Copy);
+  }
+  return defaults;
+}
+
+ShortcutsItem::ShortcutsItem(const QString& display_name, ShortcutsItem* parent) :
+  display_name_(display_name), parent_(parent), conflict_(false), is_category_(true) {}
+
+ShortcutsItem::ShortcutsItem(const QString& display_name, ShortcutsItem* parent, ShortcutType type) :
+  name_(display_name), display_name_(display_name), parent_(parent),
+  conflict_(false), type_(type), is_category_(false) {}
+
+ShortcutsItem::ShortcutsItem(const QString& name, const QString& display_name,
+                             ShortcutsItem* parent, ShortcutType type) :
+  name_(name), display_name_(display_name), parent_(parent), conflict_(false),
+  type_(type), is_category_(false) {}
+
+ShortcutsItem::~ShortcutsItem() {
+  qDeleteAll(children);
+}
+
+QAction* ShortcutsItem::createQAction(QObject* parent, Qt::ShortcutContext context) {
+  auto ptr = new QAction(name_, parent);
+  ptr->setShortcuts(shortcuts_);
+  ptr->setShortcutContext(context);
+  actions_.append(ptr);
+  return ptr;
+}
+
+QAction* ShortcutsItem::createQAction(QObject* parent, QIcon icon, Qt::ShortcutContext context) {
+  auto ptr = new QAction(icon, name_, parent);
+  ptr->setShortcuts(shortcuts_);
+  ptr->setShortcutContext(context);
+  actions_.append(ptr);
+  return ptr;
+}
+
+QString ShortcutsItem::name() const {
+  return name_;
+}
+
+QString ShortcutsItem::displayName() const {
+  return display_name_;
+}
+
+ShortcutsItem* ShortcutsItem::parent() const {
+  return parent_;
+}
+
+QList<QKeySequence> ShortcutsItem::shortcuts() const {
+  return shortcuts_;
+}
+
+QString ShortcutsItem::displayShortcuts() const {
+  return display_shortcuts_;
+}
+
+bool ShortcutsItem::deleteShortcut(const QKeySequence& shortcut) {
+  bool ret = shortcuts_.removeAll(shortcut) != 0;
+  display_shortcuts_ = QKeySequence::listToString(shortcuts_);
+  return ret;
+}
+
+bool ShortcutsItem::addShortcut(const QKeySequence& shortcut) {
+  if (!shortcuts_.contains(shortcut)) {
+    shortcuts_.append(shortcut);
+    display_shortcuts_ = QKeySequence::listToString(shortcuts_);
+    return true;
+  }
+  return false;
+}
+
+void ShortcutsItem::setConflict(bool conflict) {
+  conflict_ = conflict;
+}
+
+bool ShortcutsItem::hasConflict() const {
+  return conflict_;
+}
+
+ShortcutType ShortcutsItem::type() const {
+  return type_;
+}
+
+void ShortcutsItem::updateShortcutsForActions() {
+  QMutableListIterator<QPointer<QAction>> it(actions_);
+  while (it.hasNext()) {
+    auto action = it.next();
+    if (action) {
+      action->setShortcuts(shortcuts_);
+    } else {
+      it.remove();
+    }
+  }
+}
+
+bool ShortcutsItem::isCategory() const {
+  return is_category_;
+}
+
+QModelIndex ShortcutsModel::index(int row, int column, const QModelIndex& parent) const {
+  if (!hasIndex(row, column, parent)) {
+    return QModelIndex();
+  }
+  ShortcutsItem* parentItem = itemFromIndex(parent);
+  ShortcutsItem* child = parentItem->children.value(row);
+  if (child) {
+    return createIndex(row, column, child);
+  }
+  return QModelIndex();
+}
+
+QModelIndex ShortcutsModel::parent(const QModelIndex& index) const {
+  if (!index.isValid()) {
+    return QModelIndex();
+  }
+
+  ShortcutsItem* child = static_cast<ShortcutsItem*>(index.internalPointer());
+  ShortcutsItem* parentItem = child->parent();
+
+  if (parentItem == root_) {
+    return QModelIndex();
+  }
+  return createIndex(parentItem->children.indexOf(child), 0, parentItem);
+}
+
+int ShortcutsModel::rowCount(const QModelIndex& parent) const {
+  if (parent.column() > 0) {
+    return 0;
+  }
+  ShortcutsItem* parentItem = itemFromIndex(parent);
+  return parentItem->children.size();
+}
+
+int ShortcutsModel::columnCount(const QModelIndex& parent) const {
+  // Action name and shortcuts
+  return 2;
+}
+
+QVariant ShortcutsModel::data(const QModelIndex& index, int role) const {
+  // TODO proper icon
+  static const QIcon category_ico(":/images/open.png");
+
+  if (!index.isValid()) {
+    return QVariant();
+  }
+
+  ShortcutsItem* item = static_cast<ShortcutsItem*>(index.internalPointer());
+
+  switch (role) {
+    case Qt::DisplayRole:
+      switch (index.column()) {
+        case COLUMN_INDEX_NAME:
+          return item->displayName();
+        case COLUMN_INDEX_SHORTCUTS:
+          return item->displayShortcuts();
+        default:
+          return QVariant();
+      }
+    case Qt::ForegroundRole:
+      if (item->hasConflict()) {
+        return QColor(Qt::red);
+      }
+      return util::settings::theme::pallete().color(QPalette::Text);
+    case Qt::DecorationRole:
+      if (item->isCategory() && index.column() == COLUMN_INDEX_NAME) {
+        return category_ico;
+      } else {
+        return QVariant();
+      }
+    case CATEGORY_ROLE:
+      return item->isCategory();
+    case TYPE_ROLE:
+      return item->type();
+    case SHORTCUTS_ROLE:
+      return QVariant::fromValue(item->shortcuts());
+    default:
+      return QVariant();
+  }
+}
+
+QVariant ShortcutsModel::headerData(int section, Qt::Orientation orientation,
+                                    int role) const {
+  if (orientation != Qt::Orientation::Horizontal || role != Qt::DisplayRole) {
+    return QVariant();
+  }
+
+  switch(section) {
+    case COLUMN_INDEX_NAME:
+      return "Name";
+    case COLUMN_INDEX_SHORTCUTS:
+      return "Shortcuts";
+    default:
+      return QVariant();
+  }
+
+}
+
+ShortcutsModel* ShortcutsModel::getShortcutsModel() {
+  static ShortcutsModel* ptr = new ShortcutsModel();
+  return ptr;
+}
+
+QAction* ShortcutsModel::createQAction(
+    ShortcutType type, QObject* parent, Qt::ShortcutContext context) {
+  return type_to_shortcut_[type]->createQAction(parent, context);
+}
+
+QAction* ShortcutsModel::createQAction(
+    ShortcutType type, QObject* parent, QIcon icon, Qt::ShortcutContext context) {
+  return type_to_shortcut_[type]->createQAction(parent, icon, context);
+}
+
+void ShortcutsModel::addShortcut(ShortcutType type, const QKeySequence& shortcut) {
+  if (shortcut.isEmpty()) {
+    return;
+  }
+  auto item = type_to_shortcut_.value(type);
+  if (!item) {
+    return;
+  }
+  if (item->addShortcut(shortcut)) {
+    if (sequence_to_shortcut_.contains(shortcut) &&
+        !sequence_to_shortcut_[shortcut].contains(item)) {
+      if (sequence_to_shortcut_[shortcut].size() > 0) {
+        if (sequence_to_shortcut_[shortcut].size() == 1) {
+          sequence_to_shortcut_[shortcut][0]->setConflict(true);
+        }
+        item->setConflict(true);
+      }
+    }
+    sequence_to_shortcut_[shortcut].append(item);
+    auto index = indexFromItem(item);
+    emit dataChanged(index, index);
+  }
+}
+
+void ShortcutsModel::removeShortcut(ShortcutType type, const QKeySequence& shortcut) {
+  if (shortcut.isEmpty()) {
+    return;
+  }
+  auto item = type_to_shortcut_.value(type);
+  if (!item) {
+    return;
+  }
+  if (item->deleteShortcut(shortcut)) {
+    sequence_to_shortcut_[shortcut].removeAll(item);
+    if (sequence_to_shortcut_[shortcut].size() == 1 &&
+        !checkIfConflicts(sequence_to_shortcut_[shortcut][0])) {
+      sequence_to_shortcut_[shortcut][0]->setConflict(false);
+    }
+    if (!checkIfConflicts(item)) {
+      item->setConflict(false);
+    }
+    auto index = indexFromItem(item);
+    emit dataChanged(index, index);
+  }
+}
+
+ShortcutsModel::ShortcutsModel() : root_(new ShortcutsItem()) {
+  auto global = addCategory(tr("Global"), root_);
+  addShortcutType(EXIT_APPLICATION, global, tr("E&xit"), tr("Exit"));
+  addShortcutType(OPEN_FILE, global, tr("&Open..."), tr("Open file"));
+//  Uncomment once supported
+//  addShortcutType(NEW_FILE, global, tr("&New..."), tr("New File"));
+  addShortcutType(SHOW_DATABASE, global, tr("Show database view"));
+  addShortcutType(SHOW_LOG, global, tr("Show log view"));
+  addShortcutType(SHOW_OPTIONS, global, tr("&Options"), tr("Show the dialog to select applications options"));
+  addShortcutType(SHOW_SHORTCUT_OPTIONS, global, tr("Keyboard shortcuts"), tr("Show the dialog to customize keyboard shortcuts"));
+
+  auto docks = addCategory(tr("Docks"), global);
+  addShortcutType(DOCK_MOVE_TO_TOP, docks, tr("Move to new top level window"));
+  addShortcutType(DOCK_MOVE_TO_TOP_MAX, docks, tr("Move to new top level window and maximize"));
+  addShortcutType(DOCK_SPLIT_HORIZ, docks, tr("Split horizontally"));
+  addShortcutType(DOCK_SPLIT_VERT, docks, tr("Split vertically"));
+
+  addShortcutType(OPEN_VISUALIZATION, global, tr("&Visualization"), tr("Open visualization for current file"));
+  addShortcutType(OPEN_HEX, global, tr("Show &hex editor"), tr("Open hex editor for current file"));
+  addShortcutType(SHOW_NODE_TREE, global, tr("&Node tree"), tr("Open/close node tree for current dock"));
+  addShortcutType(SHOW_MINIMAP, global, tr("&Minimap"), tr("Open/close minimap for current dock"));
+  addShortcutType(COPY, global, tr("&Copy"), tr("Copy"));
+
+  auto network = addCategory(tr("Network"), root_);
+  addShortcutType(SHOW_CONNECT_DIALOG, network, tr("Connect..."), tr("Show connect dialog"));
+  addShortcutType(DISCONNECT_FROM_SERVER, network, tr("Disconnect"), tr("Disconnect from current server"));
+  addShortcutType(KILL_LOCAL_SERVER, network, tr("Kill locally created server"));
+
+  auto misc = addCategory(tr("Miscellaneous"), root_);
+  addShortcutType(SHOW_ABOUT, misc, tr("&About"), tr("Show the application's About box"));
+  addShortcutType(SHOW_ABOUT_QT, misc, tr("About &Qt"), tr("Show the Qt library's About box"));
+
+  auto hex = addCategory(tr("HexEdit"), root_);
+  addShortcutType(CREATE_CHUNK, hex, tr("&Create chunk"), tr("Create chunk"));
+  addShortcutType(CREATE_CHILD_CHUNK, hex, tr("&Create child chunk"), tr("Create child chunk"));
+  addShortcutType(GO_TO_ADDRESS, hex, tr("&Go to address"), tr("Go to address"));
+  addShortcutType(REMOVE_CHUNK, hex, tr("Remove chunk"));
+  addShortcutType(SAVE_SELECTION_TO_FILE, hex, tr("&Save to file"), tr("Save selection to file"));
+  addShortcutType(HEX_FIND, hex, tr("&Find/Replace"), tr("Show the dialog for finding and replacing"));
+  addShortcutType(HEX_FIND_NEXT, hex, tr("Find &next"), tr("Find next"));
+
+  auto visualization = addCategory(tr("Visualization"), root_);
+  addShortcutType(VISUALIZATION_DIGRAM, visualization, tr("&Digram"), tr("Change visualizaton mode to digram"));
+  addShortcutType(VISUALIZATION_TRIGRAM, visualization, tr("&Trigram"), tr("Change visualizaton mode to trigram"));
+  addShortcutType(VISUALIZATION_LAYERED_DIGRAM, visualization, tr("&Layered Digram"), tr("Change visualizaton mode to layered digram"));
+  addShortcutType(VISUALIZATION_OPTIONS, visualization, tr("More options"), tr("Show visualization options"));
+
+  auto three_d = addCategory(tr("3D Visualization"), visualization);
+  addShortcutType(TRIGRAM_CUBE, three_d, tr("Change 3D visualization display mode to cube"));
+  addShortcutType(TRIGRAM_CYLINDER, three_d, tr("Change 3D visualization display mode to cylinder"));
+  addShortcutType(TRIGRAM_SPHERE, three_d, tr("Change 3D visualization display mode to sphere"));
+  addShortcutType(VISUALIZATION_MANIPULATOR_SPIN, three_d, tr("Spin manipulator"), tr("Switch to spin manipulator"));
+  addShortcutType(VISUALIZATION_MANIPULATOR_TRACKBALL, three_d, tr("Trackball manipulator"), tr("Switch to trackball manipulator"));
+  addShortcutType(VISUALIZATION_MANIPULATOR_FREE, three_d, tr("Free manipulator"), tr("Switch to free manipulator"));
+}
+
+ShortcutsItem* ShortcutsModel::addCategory(const QString& name, ShortcutsItem* parent){
+  auto item = new ShortcutsItem(name, parent);
+  parent->children.append(item);
+  return item;
+}
+
+ShortcutsItem* ShortcutsModel::addShortcutType(
+    ShortcutType type, ShortcutsItem* parent, const QString& name, const QString& display_name) {
+  ShortcutsItem* item;
+  if (display_name.isEmpty()) {
+    item = new ShortcutsItem(name, parent, type);
+  } else {
+    item = new ShortcutsItem(name, display_name, parent, type);
+  }
+  assert(!type_to_shortcut_.contains(type));
+  type_to_shortcut_[type] = item;
+  auto shortcuts = getShortcuts(type);
+  for (const auto& shortcut : shortcuts) {
+    addShortcut(type, shortcut);
+  }
+  parent->children.append(item);
+  return item;
+}
+
+bool ShortcutsModel::checkIfConflicts(ShortcutsItem* item) const {
+  for (const auto& shortcut : item->shortcuts()) {
+    if (sequence_to_shortcut_[shortcut].size() > 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+ShortcutsModel::~ShortcutsModel() {
+  delete root_;
+}
+
+ShortcutsItem* ShortcutsModel::itemFromIndex(const QModelIndex& index) const {
+  if (!index.isValid()) {
+    return root_;
+  }
+  return static_cast<ShortcutsItem*>(index.internalPointer());
+}
+
+QModelIndex ShortcutsModel::indexFromItem(ShortcutsItem* item) const {
+  auto parent = item->parent();
+  return createIndex(parent->children.indexOf(item), 0, parent);
+}
+
+QList<ShortcutsItem*> ShortcutsModel::getItemsForSequence(const QKeySequence& sequence) {
+  return sequence_to_shortcut_.value(sequence);
+}
+
+void ShortcutsModel::updateShortcutsForType(ShortcutType type) {
+  auto item = type_to_shortcut_[type];
+  item->updateShortcutsForActions();
+  setShortcuts(type, item->shortcuts());
+}
+
+void ShortcutsModel::resetShortcutsForType(ShortcutType type) {
+  auto item = type_to_shortcut_[type];
+  for (const auto& shortcut : item->shortcuts()) {
+    removeShortcut(type, shortcut);
+  }
+  for (const auto& shortcut : getShortcuts(type)) {
+    addShortcut(type, shortcut);
+  }
+}
+
+void ShortcutsModel::resetShortcutsToDefault(ShortcutType type) {
+  auto shortcuts = defaultShortcuts();
+  auto item = type_to_shortcut_[type];
+  for (const auto& shortcut : item->shortcuts()) {
+    removeShortcut(type, shortcut);
+  }
+  for (const auto& shortcut : shortcuts.value(type)) {
+    addShortcut(type, shortcut);
+  }
+}
+
+void ShortcutsModel::resetAllShortcutsToDefaults() {
+  for (const auto& iter : type_to_shortcut_) {
+    resetShortcutsToDefault(iter->type());
+  }
+}
+
+QList<ShortcutType> ShortcutsModel::validShortcutTypes() const {
+  return type_to_shortcut_.keys();
+}
+
+}  // namespace shortcuts
+}  // namespace settings
+}  // namespace util
+}  // namespace veles

--- a/src/visualization/panel.cc
+++ b/src/visualization/panel.cc
@@ -24,11 +24,14 @@
 #include "util/icons.h"
 #include "util/sampling/fake_sampler.h"
 #include "util/sampling/uniform_sampler.h"
+#include "util/settings/shortcuts.h"
 #include "visualization/digram.h"
 #include "visualization/trigram.h"
 
 namespace veles {
 namespace visualization {
+
+using util::settings::shortcuts::ShortcutsModel;
 
 const std::map<QString, VisualizationPanel::ESampler>
   VisualizationPanel::k_sampler_map = {
@@ -277,8 +280,8 @@ void VisualizationPanel::initLayout() {
   ui::MainWindowWithDetachableDockWidgets::splitDockWidget2(this,
       node_tree_dock_, minimap_dock_, Qt::Horizontal);
 
-  connect(show_node_tree_act_, &QAction::toggled,
-      node_tree_dock_, &QDockWidget::setVisible);
+//  connect(show_node_tree_act_, &QAction::toggled,
+//      node_tree_dock_, &QDockWidget::setVisible);
   connect(show_minimap_act_, &QAction::toggled,
       minimap_dock_, &QDockWidget::setVisible);
 }
@@ -290,14 +293,15 @@ void VisualizationPanel::prepareVisualizationOptions() {
 void VisualizationPanel::initOptionsPanel() {
   /////////////////////////////////////
   // Node tree / minimap
-  show_node_tree_act_ = new QAction(QIcon(":/images/show_node_tree.png"),
-      tr("&Node tree"), this);
-  show_node_tree_act_->setToolTip(tr("Node tree"));
-  show_node_tree_act_->setEnabled(true);
-  show_node_tree_act_->setCheckable(true);
-  show_node_tree_act_->setChecked(false);
-  show_minimap_act_ = new QAction(QIcon(":/images/show_minimap.png"),
-      tr("&Minimap"), this);
+//  show_node_tree_act_ = new QAction(QIcon(":/images/show_node_tree.png"),
+//      tr("&Node tree"), this);
+//  show_node_tree_act_->setToolTip(tr("Node tree"));
+//  show_node_tree_act_->setEnabled(true);
+//  show_node_tree_act_->setCheckable(true);
+//  show_node_tree_act_->setChecked(false);
+  show_minimap_act_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::SHOW_MINIMAP, this,
+        QIcon(":/images/show_minimap.png"), Qt::WidgetWithChildrenShortcut);
   show_minimap_act_->setToolTip(tr("Minimap"));
   show_minimap_act_->setEnabled(true);
   show_minimap_act_->setCheckable(true);
@@ -305,6 +309,8 @@ void VisualizationPanel::initOptionsPanel() {
 
   tools_tool_bar_ = new QToolBar(tr("Tools"));
   tools_tool_bar_->setMovable(false);
+  addAction(show_minimap_act_);
+  //addAction(show_node_tree_act_);
   //tools_tool_bar_->addAction(show_node_tree_act_);
   tools_tool_bar_->addAction(show_minimap_act_);
   tools_tool_bar_->setContextMenuPolicy(Qt::PreventContextMenu);
@@ -315,27 +321,33 @@ void VisualizationPanel::initOptionsPanel() {
   /////////////////////////////////////
   // Modes: digram / trigrams
   QColor icon_color = palette().color(QPalette::WindowText);
-  digram_action_ = new QAction(util::getColoredIcon(
-      ":/images/digram_icon.png", icon_color), tr("&Digram"), this);
+  digram_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::VISUALIZATION_DIGRAM, this,
+        util::getColoredIcon(":/images/digram_icon.png", icon_color), Qt::WidgetWithChildrenShortcut);
   digram_action_->setToolTip("Digram Visualization");
   connect(digram_action_, SIGNAL(triggered()), this,
           SLOT(showDigramVisualization()));
 
-  trigram_action_ = new QAction(util::getColoredIcon(
-      ":/images/trigram_icon.png", icon_color), tr("&Trigram"), this);
+  trigram_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::VISUALIZATION_TRIGRAM, this,
+        util::getColoredIcon(":/images/trigram_icon.png", icon_color), Qt::WidgetWithChildrenShortcut);
   trigram_action_->setToolTip("Trigram Visualization");
   connect(trigram_action_, SIGNAL(triggered()), this,
           SLOT(showTrigramVisualization()));
 
-  layered_digram_action_ = new QAction(util::getColoredIcon(
-      ":/images/layered_digram_icon.png", icon_color, false),
-      tr("&Layered Digram"), this);
+
+  layered_digram_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::VISUALIZATION_LAYERED_DIGRAM, this,
+        util::getColoredIcon(":/images/layered_digram_icon.png", icon_color, false), Qt::WidgetWithChildrenShortcut);
   layered_digram_action_->setToolTip("Layered Digram Visualization");
   connect(layered_digram_action_, SIGNAL(triggered()), this,
           SLOT(showLayeredDigramVisualization()));
 
   modes_tool_bar_ = new QToolBar(tr("Modes"));
   modes_tool_bar_->setMovable(false);
+  addAction(digram_action_);
+  addAction(trigram_action_);
+  addAction(layered_digram_action_);
   modes_tool_bar_->addAction(digram_action_);
   modes_tool_bar_->addAction(trigram_action_);
   modes_tool_bar_->addAction(layered_digram_action_);
@@ -362,10 +374,13 @@ void VisualizationPanel::initOptionsPanel() {
 
   /////////////////////////////////////
   // Sampling
-  QAction* show_more_options_action = new QAction(QIcon(":/images/more.png"),
-      tr("More options"), this);
+
+  QAction* show_more_options_action = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::VISUALIZATION_OPTIONS, this,
+        QIcon(":/images/more.png"), Qt::WidgetWithChildrenShortcut);
   connect(show_more_options_action, &QAction::triggered,
       this, &VisualizationPanel::showMoreOptions);
+  addAction(show_more_options_action);
   selection_toolbar->addAction(show_more_options_action);
 
   /////////////////////////////////////

--- a/src/visualization/trigram.cc
+++ b/src/visualization/trigram.cc
@@ -41,6 +41,8 @@
 namespace veles {
 namespace visualization {
 
+using util::settings::shortcuts::ShortcutsModel;
+
 const int k_minimum_brightness = 25;
 const int k_maximum_brightness = 103;
 const double k_brightness_heuristic_threshold = 0.66;
@@ -133,23 +135,23 @@ void TrigramWidget::prepareOptions(QMainWindow* visualization_window) {
   // Shape
   QToolBar* shape_toolbar = new QToolBar("Shape", this);
   shape_toolbar->setMovable(false);
-  cube_action_ = new QAction(this);
-  cube_action_->setIcon(
-      util::getColoredIcon(":/images/cube.png", icon_color, false));
+  cube_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::TRIGRAM_CUBE, this,
+        util::getColoredIcon(":/images/cube.png", icon_color, false));
   connect(cube_action_, &QAction::triggered, std::bind(
       &TrigramWidget::setShape, this, EVisualizationShape::CUBE));
   shape_toolbar->addAction(cube_action_);
 
-  cylinder_action_ = new QAction(this);
-  cylinder_action_->setIcon(
-      util::getColoredIcon(":/images/cylinder.png", icon_color, false));
+  cylinder_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::TRIGRAM_CYLINDER, this,
+        util::getColoredIcon(":/images/cylinder.png", icon_color, false));
   connect(cylinder_action_, &QAction::triggered, std::bind(
       &TrigramWidget::setShape, this, EVisualizationShape::CYLINDER));
   shape_toolbar->addAction(cylinder_action_);
 
-  sphere_action_ = new QAction(this);
-  sphere_action_->setIcon(
-      util::getColoredIcon(":/images/sphere.png", icon_color));
+  sphere_action_ = ShortcutsModel::getShortcutsModel()->createQAction(
+        util::settings::shortcuts::TRIGRAM_SPHERE, this,
+        util::getColoredIcon(":/images/sphere.png", icon_color));
 
   connect(sphere_action_, &QAction::triggered,
       std::bind(&TrigramWidget::setShape, this, EVisualizationShape::SPHERE));
@@ -428,11 +430,10 @@ void TrigramWidget::initGeometry() {
   vao_.create();
 }
 
-QAction* TrigramWidget::createAction(const QIcon& icon,
-      Manipulator* manipulator, const QList<QKeySequence>& sequences) {
-  QAction* action = new QAction(icon, manipulator->manipulatorName(), this);
-  action->setShortcuts(sequences);
-  action->setShortcutContext(Qt::WidgetWithChildrenShortcut);
+QAction* TrigramWidget::createAction(util::settings::shortcuts::ShortcutType type, const QIcon& icon,
+      Manipulator* manipulator) {
+  auto action = ShortcutsModel::getShortcutsModel()->createQAction(
+        type, this, icon, Qt::WidgetWithChildrenShortcut);
   connect(action, &QAction::triggered, std::bind(
       &TrigramWidget::setManipulator, this, manipulator));
   action->setProperty("manipulator", QVariant(qintptr(manipulator)));
@@ -478,25 +479,22 @@ void TrigramWidget::prepareManipulatorToolbar(
   manipulator_toolbar->setMovable(false);
 
   {
-    QAction* action = createAction(
-        QIcon(":/images/manipulator_spin.png"), spin_manipulator_,
-        {QKeySequence(Qt::CTRL + Qt::Key_1), QKeySequence(Qt::Key_Escape)});
+    QAction* action = createAction(util::settings::shortcuts::VISUALIZATION_MANIPULATOR_SPIN,
+        QIcon(":/images/manipulator_spin.png"), spin_manipulator_);
     addAction(action);
     manipulator_toolbar->addAction(action);
   }
 
   {
-    QAction* action = createAction(
-        QIcon(":/images/manipulator_trackball.png"), trackball_manipulator_,
-        {QKeySequence(Qt::CTRL + Qt::Key_2)});
+    QAction* action = createAction(util::settings::shortcuts::VISUALIZATION_MANIPULATOR_TRACKBALL,
+        QIcon(":/images/manipulator_trackball.png"), trackball_manipulator_);
     addAction(action);
     manipulator_toolbar->addAction(action);
   }
 
   {
-    QAction* action = createAction(
-        QIcon(":/images/manipulator_free.png"), free_manipulator_,
-        {QKeySequence(Qt::CTRL + Qt::Key_3)});
+    QAction* action = createAction(util::settings::shortcuts::VISUALIZATION_MANIPULATOR_FREE,
+        QIcon(":/images/manipulator_free.png"), free_manipulator_);
     addAction(action);
     manipulator_toolbar->addAction(action);
   }


### PR DESCRIPTION
Keyboard shortcuts for all action types are saved in settings,
they are editable through new dialog available in file menu.
All existing QActions that weren't generated based on some data
were converted to support editing shortcuts for them.