### PR TITLE
Call removeTab in tabCloseRequested

### DIFF
--- a/src/ui/dockwidget.cc
+++ b/src/ui/dockwidget.cc
@@ -1066,6 +1066,7 @@ void MainWindowWithDetachableDockWidgets::tabCloseRequested(int index) {
     if(dock_widget) {
       dock_widget->deleteLater();
     }
+    tab_bar->removeTab(index);
   }
 }
 


### PR DESCRIPTION
Without it was possible that Qt sent another tabCloseRequested signal
for the same dock_widget which was already deleted, but not yet removed from
internal tabData pointer