### PR TITLE
Move PROTO_VERSION from veles.server to veles.proto

### DIFF
--- a/python/veles/async_client/proto.py
+++ b/python/veles/async_client/proto.py
@@ -24,7 +24,7 @@ import msgpack
 
 from veles.proto import messages, msgpackwrap
 from veles.proto.exceptions import VelesException, SchemaError
-from veles.server.proto import PROTO_VERSION
+from veles.proto.messages import PROTO_VERSION
 from veles.util.helpers import prepare_auth_key
 
 logger = logging.getLogger('veles.async_client')

--- a/python/veles/proto/messages.py
+++ b/python/veles/proto/messages.py
@@ -22,6 +22,8 @@ from veles.proto.connection import Connection
 from veles.schema import model, fields
 from veles.schema.nodeid import NodeID
 
+PROTO_VERSION = 1
+
 
 class MsgpackMsg(model.PolymorphicModel):
     pass

--- a/python/veles/scli/client.py
+++ b/python/veles/scli/client.py
@@ -17,8 +17,8 @@ import socket
 import msgpack
 
 from veles.proto import messages, msgpackwrap
+from veles.proto.messages import PROTO_VERSION
 from veles.schema import nodeid
-from veles.server.proto import PROTO_VERSION
 from veles.util.helpers import prepare_auth_key
 
 

--- a/python/veles/server/proto.py
+++ b/python/veles/server/proto.py
@@ -23,6 +23,7 @@ import hmac
 import msgpack
 
 from veles.proto import messages, msgpackwrap
+from veles.proto.messages import PROTO_VERSION
 from veles.util.helpers import prepare_auth_key
 from veles.db.subscriber import (
     BaseSubscriberNode,
@@ -49,9 +50,6 @@ from veles.proto.exceptions import (
     ProtocolMismatchError,
     AuthenticationError,
 )
-
-# TODO generate this as a constant in C++
-PROTO_VERSION = 1
 
 
 class SubscriberNode(BaseSubscriberNode):


### PR DESCRIPTION
Importing veles.server from veles.scli breaks Python 2 for obvious reasons.

Reported by mkow.