### PR TITLE
scli: Use unicode_literals

### DIFF
--- a/python/make_blob
+++ b/python/make_blob
@@ -2,12 +2,14 @@
 
 from __future__ import unicode_literals, print_function
 
+from six import text_type
+
 from veles.scli import client
 from veles.schema.nodeid import NodeID
 from veles.util import helpers
 
 parser = helpers.get_client_argparse()
-parser.add_argument('file', help='path to file to upload')
+parser.add_argument('file', help='path to file to upload', type=text_type)
 args = parser.parse_args()
 
 client = client.create_client(args.server, args.server_auth_key)

--- a/python/upload_elf
+++ b/python/upload_elf
@@ -2,12 +2,14 @@
 
 from __future__ import unicode_literals, print_function
 
+from six import text_type
+
 from veles.scli import client
 from veles.schema.nodeid import NodeID
 from veles.util import helpers
 
 parser = helpers.get_client_argparse()
-parser.add_argument('file', help='path to file to upload')
+parser.add_argument('file', help='path to file to upload', type=text_type)
 args = parser.parse_args()
 
 client = client.create_client(args.server, args.server_auth_key)

--- a/python/veles/scli/client.py
+++ b/python/veles/scli/client.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+
 import socket
 
 import msgpack


### PR DESCRIPTION
Fixes python2 problems with invalid type of client_name etc.