### PR TITLE
Add missing cert-dir argument when starting server

### DIFF
--- a/src/ui/connectionmanager.cc
+++ b/src/ui/connectionmanager.cc
@@ -180,7 +180,8 @@ void ConnectionManager::startLocalServer() {
       .arg(connection_dialog_->authenticationKey())
       .arg(connection_dialog_->serverHost())
       .arg(connection_dialog_->serverPort())
-      << connection_dialog_->databaseFile();
+      << connection_dialog_->databaseFile()
+      << "--cert-dir" << connection_dialog_->certificateDir();
 
 #if defined(Q_OS_LINUX)
   QString python_interpreter_executable("/usr/share/veles-server/venv/bin/python3");


### PR DESCRIPTION
Because of that missing flag, after installing veles from the provided deb package and starting it as a normal user you will get:
```
Trying to start a new server...
    working directory: /usr/share/veles-server
    python script name: srv.py
    python interpreter executable: /usr/share/veles-server/venv/bin/python3
    arguments:
        srv.py
        veles+ssl://@127.0.0.1:3135
        /home/p2004a/.local/share/Codisec/Veles/veles.vdb

Waiting for a new server to start...
Process of locally created server started.
INFO:root:Świtezianka server is starting up...
INFO:root:Opening database...
INFO:root:Loading plugins...
INFO:root:Starting SSL server...
Traceback (most recent call last):
  File "srv.py", line 71, in <module>
    conn, url.auth_key, url.host, url.port, args.cert_dir))
  File "/usr/lib/python3.5/asyncio/base_events.py", line 467, in run_until_complete
    return future.result()
  File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
    raise self._exception
  File "/usr/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/usr/share/veles-server/venv/lib/python3.5/site-packages/veles/server/proto.py", line 737, in create_ssl_server
    helpers.generate_ssl_cert(cert_path, key_path)
  File "/usr/share/veles-server/venv/lib/python3.5/site-packages/veles/util/helpers.py", line 90, in generate_ssl_cert
    with open(cert_path, 'w') as f:
PermissionError: [Errno 13] Permission denied: './veles.cert'
Process of locally created server finished. Exit code: 1.
```