### PR TITLE
Wip/mkow/fix scroll with selection

### DIFF
--- a/include/ui/hexedit.h
+++ b/include/ui/hexedit.h
@@ -48,7 +48,7 @@ class HexEdit : public QAbstractScrollArea {
   /** Scroll screen to make byte visible */
   void scrollToByte(qint64 bytePos, bool minimal_change = false);
   void scrollRows(qint64 num_rows);
-  FileBlobModel *dataModel() { return dataModel_;};
+  FileBlobModel *dataModel() { return dataModel_;}
   void setParserIds(QStringList ids);
   void processEditEvent(QKeyEvent *event);
   uint64_t byteValue(qint64 pos, bool modified = true);

--- a/include/util/settings/shortcuts.h
+++ b/include/util/settings/shortcuts.h
@@ -102,6 +102,8 @@ enum ShortcutType : uint32_t {
   DOCK_CLOSE = 67,
   SWITCH_TAB_NEXT = 68,
   SWITCH_TAB_PREV = 69,
+  HEX_SCROLL_UP = 70,
+  HEX_SCROLL_DOWN = 71,
 };
 
 QMap<ShortcutType, QList<QKeySequence>> defaultShortcuts();

--- a/src/ui/hexedit.cc
+++ b/src/ui/hexedit.cc
@@ -822,7 +822,7 @@ void HexEdit::setSelection(qint64 start, qint64 size, bool set_visible) {
   createChunkDialog_->setRange(selectionStart(), selectionEnd());
 
   if (set_visible ) {
-    scrollToByte(selectionStart(), /*minimal_change=*/true);
+    scrollToByte(current_position_, /*minimal_change=*/true);
   }
 
   resetCursor();

--- a/src/ui/hexedit.cc
+++ b/src/ui/hexedit.cc
@@ -350,6 +350,14 @@ HexEdit::HexEdit(FileBlobModel *dataModel, QItemSelectionModel *selectionModel,
     scrollToByte(current_position_, /*minimal_change=*/true);
   });
 
+  createAction(util::settings::shortcuts::HEX_SCROLL_UP, [this]() {
+    scrollRows(-1);
+  });
+
+  createAction(util::settings::shortcuts::HEX_SCROLL_DOWN, [this]() {
+    scrollRows(1);
+  });
+
   createAction(util::settings::shortcuts::HEX_SELECT_NEXT_PAGE, [this]() {
     setSelectionEnd(current_position_ + bytesPerRow_ * rowsOnScreen_);
     scrollRows(rowsOnScreen_);
@@ -394,7 +402,7 @@ QModelIndex HexEdit::selectedChunk() {
   return chunkSelectionModel_->currentIndex();
 }
 
-void HexEdit::createAction(util::settings::shortcuts::ShortcutType type, const std::function<void ()>& f) {
+void HexEdit::createAction(util::settings::shortcuts::ShortcutType type, const std::function<void()>& f) {
   auto action = ShortcutsModel::getShortcutsModel()->createQAction(
       type, this, Qt::WidgetWithChildrenShortcut);
   connect(action, &QAction::triggered, f);

--- a/src/util/settings/shortcuts.cc
+++ b/src/util/settings/shortcuts.cc
@@ -107,6 +107,8 @@ QMap<ShortcutType, QList<QKeySequence>> defaultShortcuts() {
     defaults[DOCK_CLOSE] = QKeySequence::keyBindings(QKeySequence::Close);
     defaults[SWITCH_TAB_NEXT] = {QKeySequence(Qt::CTRL | Qt::Key_Tab), QKeySequence(Qt::CTRL | Qt::Key_PageDown)};
     defaults[SWITCH_TAB_PREV] = {QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_Tab), QKeySequence(Qt::CTRL | Qt::Key_PageUp)};
+    defaults[HEX_SCROLL_UP] = {QKeySequence(Qt::CTRL | Qt::Key_Up)};
+    defaults[HEX_SCROLL_DOWN] = {QKeySequence(Qt::CTRL | Qt::Key_Down)};
   }
   return defaults;
 }
@@ -418,6 +420,8 @@ ShortcutsModel::ShortcutsModel() : root_(new ShortcutsItem()) {
   addShortcutType(HEX_MOVE_TO_PREV_CHAR, hex_move, tr("Left"));
   addShortcutType(HEX_MOVE_TO_NEXT_LINE, hex_move, tr("Down"));
   addShortcutType(HEX_MOVE_TO_PREV_LINE, hex_move, tr("Up"));
+  addShortcutType(HEX_SCROLL_UP, hex_move, tr("Scroll up one line"));
+  addShortcutType(HEX_SCROLL_DOWN, hex_move, tr("Scroll down one line"));
   addShortcutType(HEX_MOVE_TO_NEXT_PAGE, hex_move, tr("Page down"));
   addShortcutType(HEX_MOVE_TO_PREV_PAGE, hex_move, tr("Page up"));
   addShortcutType(HEX_MOVE_TO_START_OF_LINE, hex_move, tr("Start of line"));


### PR DESCRIPTION
* This fixes auto scrolling when moving selection with the cursor at its end.
* Adds shortcuts for scrolling without moving cursor and without a need to place it at the edge of view.