### PR TITLE
clang-tidy, clang-format and Jenkinsfile improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
 endif()
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc ") # set exception handling mode and linking mode
+  # build with multiple processes
+  # see: https://docs.microsoft.com/en-us/cpp/build/reference/mp-build-with-multiple-processes
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP ")
 endif()
 if(APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -544,6 +544,26 @@ else()
 endif()
 
 
+message(STATUS "Looking for clang-format")
+find_program(CLANG_FORMAT NAMES clang-format clang-format-4.0 clang-format-3.9 clang-format-3.8 clang-format-3.7 clang-format-3.6 clang-format-3.5)
+
+if(CLANG_FORMAT)
+  message(STATUS "Looking for clang-format - found")
+  file(GLOB_RECURSE LINT_ALL_SOURCE_FILES src/*.cc)
+  add_custom_target(
+    format
+    COMMAND
+      ${CLANG_FORMAT}
+      -style=Google
+      -sort-includes
+      -i
+      ${LINT_ALL_SOURCE_FILES}
+  )
+else()
+    message(STATUS "Looking for clang-format - not found")
+    message(STATUS "  Build target 'format' will not be available.")
+endif()
+
 ####
 
 # Post-build packaging

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,88 @@ endif(GTEST_FOUND AND GMOCK_FOUND)
 target_link_libraries(main_ui veles_base veles_db veles_network veles_client veles_visualization Qt5::Widgets parser)
 set_target_properties(main_ui PROPERTIES OUTPUT_NAME "veles")
 
+###
+#   Post-build - linting ###
+###
+
+message(STATUS "Looking for clang-tidy")
+find_program(CLANG_TIDY NAMES clang-tidy clang-tidy-4.0 clang-tidy-3.9 clang-tidy-3.8 clang-tidy-3.7 clang-tidy-3.6 clang-tidy-3.5)
+
+if(CLANG_TIDY)
+  message(STATUS "Looking for clang-tidy - found")
+  file(GLOB_RECURSE LINT_ALL_SOURCE_FILES src/*.cc)
+
+  # Get includes from main file
+  get_property(LINT_INC_DIRS TARGET main_ui PROPERTY INCLUDE_DIRECTORIES)
+
+  # Get includes from network library (QNetwork and friends)
+  get_property(LINT_VELES_NETWORK_DIRS TARGET veles_network PROPERTY INCLUDE_DIRECTORIES)
+
+  # join the lists of the includes
+  list(APPEND LINT_INC_DIRS ${LINT_VELES_NETWORK_DIRS})
+
+  # use this hack, so cmake will not escape space characters when passing the list
+  # to COMMAND, for example by using "-I$<JOIN:${LINT_INC_DIRS}, -I>"
+  string(REPLACE ";" ";-I" LINT_INCLUDES "${LINT_INC_DIRS}")
+
+  # checks
+  list(APPEND LINT_CHECKS "google-*")
+
+  string(REPLACE ";" "," LINT_CHECKS_STR "${LINT_CHECKS}")
+  message(STATUS "clang-tidy includes: -I${LINT_INCLUDES} -I${CMAKE_BINARY_DIR} -I${PROJECT_SOURCE_DIR}")
+  message(STATUS "clang-tidy checks: ${LINT_CHECKS_STR}")
+  # parse CMAKE_CXX_FLAGS to list, so spaces will not be escaped in COMMANDs
+  separate_arguments(LINT_CXX_FLAGS UNIX_COMMAND ${CMAKE_CXX_FLAGS})
+
+  # as an alternative - we could use
+  # set(CMAKE_CXX_CLANG_TIDY clang-tidy;-style=google;-checks=${LINT_CHECKS_STR}")
+  # and then all the magic should happen at compile time
+  # cmake 3.6+ required (Ubuntu 18.04 LTS)
+  add_custom_target(lint)
+
+
+  # this target is needed so dependencies are not build for each clang-tidy call
+  add_custom_target(lint_depends
+          DEPENDS
+            ${MSGPACK_CPP_HEADER}
+            ${MSGPACK_EXTRACT_PATH}
+            ${FORMS}
+            ${VISUALIZATION_FORMS}
+  )
+
+  # foreach is needed so maximum command line length is not reached
+  # create intermediary targets to allow parallel checks with -jN
+  foreach(LINT_SOURCE_FILE ${LINT_ALL_SOURCE_FILES})
+    list(APPEND LINT_ADDED_TARGETS ${LINT_SOURCE_FILE})
+    list(LENGTH LINT_ADDED_TARGETS LINT_ADDED_TARGETS_LEN)
+    set(LINT_TARGET_NAME "lint-${LINT_ADDED_TARGETS_LEN}")
+    add_custom_target(
+        ${LINT_TARGET_NAME}
+        COMMAND
+            ${CLANG_TIDY}
+            -checks=${LINT_CHECKS_STR}
+            ${LINT_SOURCE_FILE}
+            --
+            ${LINT_CXX_FLAGS}
+            # Don't know how to get from CMake that he will invoke compiler with
+            # -fPIC
+            "$<$<NOT:$<OR:$<BOOL:${WIN32}>,$<BOOL:${WIN64}>>>:-fPIC>"
+            -I${LINT_INCLUDES}
+            -I${CMAKE_BINARY_DIR}
+            -I${PROJECT_SOURCE_DIR}
+          DEPENDS
+            lint_depends
+    )
+    add_dependencies(lint ${LINT_TARGET_NAME})
+  endforeach()
+else()
+    message(STATUS "Looking for clang-tidy - not found")
+    message(STATUS "  Build target 'lint' will not be available.")
+endif()
+
+
+####
+
 # Post-build packaging
 
 #Unix paths

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,8 +181,10 @@ builders['ubuntu-16.04'] = { node ('ubuntu-16.04'){
               dir ("build") {
                 def branch = getBranch()
                 sh """cmake -DGOOGLETEST_SRC_PATH=\"${tool 'googletest'}\" -DCMAKE_BUILD_TYPE=${buildConfiguration} .."""
-                sh "cmake --build . --config ${buildConfiguration} -- -j3 > error_and_warnings.txt 2>&1"
-                sh "cat error_and_warnings.txt"
+                sh """#!/bin/bash -ex
+                  set -o pipefail
+                  cmake --build . --config ${buildConfiguration} -- -j3 2>&1 | tee error_and_warnings.txt
+                """
                 sh "cpack -D CPACK_PACKAGE_FILE_NAME=veles-ubuntu1604 -G \"ZIP;DEB\" -C ${buildConfiguration}"
                 junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/results.xml'
                 step([$class: 'ArtifactArchiver', artifacts: 'veles-ubuntu1604.*', fingerprint: true])
@@ -192,7 +194,6 @@ builders['ubuntu-16.04'] = { node ('ubuntu-16.04'){
               }
               sh 'rm -Rf build'
             } catch (error) {
-              sh "cat build/error_and_warnings.txt"
               post_stage_failure(env.JOB_NAME, "ubuntu-16.04-amd64", env.BUILD_ID, env.BUILD_URL)
               throw error
             }
@@ -234,7 +235,10 @@ builders['macosx'] = { node ('macosx'){
               dir ("build") {
                 def branch = getBranch()
                 sh "cmake .. -G \"Xcode\" -DCMAKE_PREFIX_PATH=$QT/5.7/clang_64 -DGOOGLETEST_SRC_PATH=\"${tool 'googletest'}\""
-                sh "cmake --build . --config ${buildConfiguration} > error_and_warnings.txt 2>&1"
+                sh """#!/bin/bash -ex
+                  set -o pipefail
+                  cmake --build . --config ${buildConfiguration} 2>&1 | tee error_and_warnings.txt
+                """
                 sh "cat error_and_warnings.txt"
                 sh "cpack -D CPACK_PACKAGE_FILE_NAME=veles-osx -G \"DragNDrop;ZIP\" -C ${buildConfiguration}"
                 junit allowEmptyResults: true, keepLongStdio: true, testResults: 'results.xml'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,7 +289,7 @@ builders['macosx'] = { node ('macosx'){
             try {
               dir ("build") {
                 def branch = getBranch()
-                sh "cmake .. -G \"Xcode\" -DCMAKE_PREFIX_PATH=$QT/5.7/clang_64 -DGOOGLETEST_SRC_PATH=\"${tool 'googletest'}\""
+                sh "cmake .. -DCMAKE_PREFIX_PATH=$QT/5.7/clang_64 -DGOOGLETEST_SRC_PATH=\"${tool 'googletest'}\""
                 sh """#!/bin/bash -ex
                   set -o pipefail
                   cmake --build . --config ${buildConfiguration} 2>&1 | tee errors_and_warnings.txt

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ builders['msvc2015_64'] = { node('windows'){
               bat script: "md build_${version}", returnStatus: true
               dir ("build_${version}") {
                 bat script: "cmake -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DGOOGLETEST_SRC_PATH=%GOOGLETEST_DIR% -DEMBED_PYTHON_ARCHIVE_PATH=%EMBED_PYTHON_ARCHIVE_PATH% -DVCREDIST_BINARY=\"${vcredist_binary}\" -DOPENSSL_DLL_DIR=${tool 'openssl-64'} -G \"${generator}\" ..\\"
-                bat script: "cmake --build . --config ${buildConfiguration} > error_and_warnings.txt"
+                bat script: "cmake --build . --config ${buildConfiguration} -- /maxcpucount:8 > error_and_warnings.txt"
                 bat script: "type error_and_warnings.txt"
                 bat script: "cpack -D CPACK_PACKAGE_FILE_NAME=veles-${version} -G \"${cpack_generator}\" -C ${buildConfiguration}"
               }
@@ -122,7 +122,7 @@ builders['msvc2015'] = {node('windows'){
               bat script: "md build_${version}", returnStatus: true
               dir ("build_${version}") {
                 bat script: "cmake -DCMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH% -DGOOGLETEST_SRC_PATH=%GOOGLETEST_DIR% -DEMBED_PYTHON_ARCHIVE_PATH=%EMBED_PYTHON_ARCHIVE_PATH% -DVCREDIST_BINARY=\"${vcredist_binary}\" -DOPENSSL_DLL_DIR=${tool 'openssl-32'} -G \"${generator}\" ..\\"
-                bat script: "cmake --build . --config ${buildConfiguration}"
+                bat script: "cmake --build . --config ${buildConfiguration} -- /maxcpucount:8"
                 bat script: "cpack -D CPACK_PACKAGE_FILE_NAME=veles-${version} -G \"${cpack_generator}\" -C ${buildConfiguration}"
               }
               junit allowEmptyResults: true, keepLongStdio: true, testResults: '**/results.xml'

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,7 @@ Dependencies:
     - ``virtualenv``
 - ``OpenSSL`` >= 1.0.0, < 1.1.0
 - ``clang-tidy``
+- ``clang-format``
 - ``libclang-common-dev``
 
 Caveats:
@@ -34,7 +35,7 @@ corresponding to the dependencies above.
 
 On Ubuntu it can be done like this::
 
-    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev clang-tidy-3.9 libclang-common-3.9-dev
+    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev clang-tidy-3.9 clang-format-3.9 libclang-common-3.9-dev
 
 To build ::
 

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ Dependencies:
 - ``Python3.5+``
     - ``virtualenv``
 - ``OpenSSL`` >= 1.0.0, < 1.1.0
+- ``clang-tidy``
+- ``libclang-common-dev``
 
 Caveats:
 ``qt`` >= 5.6 is required if you want to rearrange tabs using drag&drop.
@@ -32,7 +34,7 @@ corresponding to the dependencies above.
 
 On Ubuntu it can be done like this::
 
-    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev
+    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev clang-tidy-3.9 libclang-common-3.9-dev
 
 To build ::
 


### PR DESCRIPTION
1. Add target lint to CMake to check against Google checks
2. Add target format to CMake to check against errors in code formatting
3. Add lint and format targets to Jenkinsfile and WarningsPublisher
4. Improve performance of builds on Windows
5. Bring back pipes and tee when gathering errors and warnings for WarningsPublisher
6. Do not use XCode generator for CMake. That allows building on MacOS with only Command Line Developer Tools installed