### PR TITLE
Fix RPATH on MacOSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -519,6 +519,7 @@ endif(WIN32)
 # Apple
 if(APPLE)
   set(CPACK_INSTALL_PREFIX "/Applications")
+  set(CMAKE_MACOSX_RPATH on)
   # Finding MacDeployQt
   find_program(MACDEPLOYQT_EXECUTABLE
     macdeployqt


### PR DESCRIPTION
Add `@executable_path/../Frameworks` to RPATH on MacOSX, so Qt will be properly found after installing Veles on Mac.