### PR TITLE
Make HexEdit::paintEvent() 2x faster

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   set(ADDITIONAL_LINK_LIBRARIES "pthread")
 endif()
 if(MSVC)
+  # Uncomment this line to use instrumentation in Visual Studio.
+  # set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /Profile")
+
   # set exception handling mode and linking mode
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc ")
   # build with multiple processes
@@ -99,6 +102,7 @@ add_library(veles_base
     ${INCLUDE_DIR}/util/edit.h
     ${INCLUDE_DIR}/util/string_utils.h
     ${INCLUDE_DIR}/util/math.h
+    ${INCLUDE_DIR}/util/misc.h
 
     ${SRC_DIR}/util/icons.cc
     ${SRC_DIR}/util/concurrency/threadpool.cc
@@ -122,6 +126,7 @@ add_library(veles_base
     ${SRC_DIR}/util/edit.cc
     ${SRC_DIR}/util/string_utils.cc
     ${SRC_DIR}/util/math.cc
+    ${SRC_DIR}/util/misc.cc
     ${SRC_DIR}/util/version.cc)
 
 qt5_use_modules(veles_base Core Gui Widgets)

--- a/include/ui/fileblobitem.h
+++ b/include/ui/fileblobitem.h
@@ -33,6 +33,7 @@ class FileBlobItem : public QObject {
   explicit FileBlobItem(QString name, QString value, QString comment,
                         uint64_t start, uint64_t end, QObject *parent);
 
+  virtual const QVector<FileBlobItem*>& children() const { return children_; }
   virtual int childrenCount();
   virtual FileBlobItem *child(int index);
   virtual int childIndex(FileBlobItem *child);
@@ -65,7 +66,7 @@ class FileBlobItem : public QObject {
   dbif::ObjectHandle newRoot_;
 
   dbif::ObjectHandle dataObj_;
-  QList<FileBlobItem *> children_;
+  QVector<FileBlobItem *> children_;
 
  private:
   bool sortChildren();

--- a/include/ui/hexedit.h
+++ b/include/ui/hexedit.h
@@ -22,6 +22,7 @@
 #include <QItemSelectionModel>
 #include <QMenu>
 #include <QMouseEvent>
+#include <QStaticText>
 #include <QStringList>
 
 #include "ui/createchunkdialog.h"
@@ -89,7 +90,6 @@ public slots:
   qint64 bytesPerRow_;
   /** Indicates if bytes per row should be automatically adjusted to window width */
   bool autoBytesPerRow_;
-
   /** Byte offset of whole blob */
   qint64 startOffset_;
   /** Total number of rows in hex edit (counting last address only row) */
@@ -120,11 +120,19 @@ public slots:
   qint64 asciiWidth_;
   /** Height in pixels of area separator */
   qint64 lineWidth_;
-
   /** Number of first row displayed on the screen */
   qint64 startRow_;
   /** Number of first pixel from left which should be displayed on the screen */
   qint64 startPosX_;
+  /** Number of byte where selection starts (counting from beginning of blob) */
+  qint64 current_position_;
+  /** Number of bytes in selection */
+  qint64 selection_size_;
+
+  // Cache for faster rendering.
+  QStaticText hex_text_cache_[256];
+  QStaticText ascii_text_cache_[256];
+  QColor selectionColor_;
 
   enum class WindowArea {
     ADDRESS,
@@ -132,11 +140,6 @@ public slots:
     ASCII,
     OUTSIDE,
   };
-
-  /** Number of byte where selection starts (counting from beginning of blob) */
-  qint64 current_position_;
-  /** Number of bytes in selection */
-  qint64 selection_size_;
 
   WindowArea current_area_;
   qint64 cursor_pos_in_byte_;
@@ -170,11 +173,11 @@ public slots:
   void flipCursorVisibility();
   WindowArea pointToWindowArea(QPoint pos);
   QString addressAsText(qint64 pos);
-  QString hexRepresentationFromBytePos(qint64 pos);
-  QString asciiRepresentationFromBytePos(qint64 pos);
+  QString hexRepresentationFromByte(uint64_t byte_val);
+  QString asciiRepresentationFromByte(uint64_t byte_val);
 
   void setByteValue(qint64 pos, uint64_t byte_value);
-  QColor byteTextColorFromPos(qint64 pos);
+  QColor byteTextColorFromByteValue(uint64_t byte_val);
   QColor byteBackroundColorFromPos(qint64 pos);
 
   qint64 selectionStart();

--- a/include/ui/nodetreewidget.h
+++ b/include/ui/nodetreewidget.h
@@ -72,9 +72,6 @@ class NodeTreeWidget : public View {
 
   MainWindowWithDetachableDockWidgets *main_window_;
 
-  QFile file_;
-  bool is_untitled;
-
   QToolBar *file_tool_bar_;
   QToolBar *edit_tool_bar_;
   QToolBar *tools_tool_bar_;

--- a/include/util/misc.h
+++ b/include/util/misc.h
@@ -1,0 +1,30 @@
+/*
+* Copyright 2016 CodiLime
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+
+#include <cstddef>
+
+namespace veles {
+namespace util {
+namespace misc {
+
+  template<size_t SIZE, class T> inline size_t array_size(T (&arr)[SIZE]) {
+    return SIZE;
+  }
+
+}  // namespace misc
+}  // namespace util
+}  // namespace veles

--- a/src/ui/fileblobmodel.cc
+++ b/src/ui/fileblobmodel.cc
@@ -263,6 +263,7 @@ QVariant FileBlobModel::data(const QModelIndex& index, int role) const {
         return color(index.row());
       }
     }
+    return QVariant();
   }
 
   if (item == nullptr) return QVariant();
@@ -300,12 +301,11 @@ QModelIndex FileBlobModel::indexFromPos(uint64_t pos,
     return QModelIndex();
   }
 
-  for (int childIndex = 0; childIndex < loader->childrenCount(); childIndex++) {
-    auto loaderChild = loader->child(childIndex);
+  for (const auto loader_child : loader->children()) {
     uint64_t begin, end;
-    loaderChild->range(&begin, &end);
+    loader_child->range(&begin, &end);
     if (pos >= begin && pos < end) {
-      return indexFromItem(loaderChild);
+      return indexFromItem(loader_child);
     }
   }
 

--- a/src/util/misc.cc
+++ b/src/util/misc.cc
@@ -1,0 +1,25 @@
+/*
+* Copyright 2016 CodiLime
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+*/
+#include "util/misc.h"
+
+namespace veles {
+namespace util {
+namespace misc {
+
+}  // namespace misc
+}  // namespace util
+}  // namespace veles

--- a/src/util/settings/theme.cc
+++ b/src/util/settings/theme.cc
@@ -88,7 +88,6 @@ QColor chunkBackground(int colorIndex) {
   }
   QColor ret =
       chunkBackgroundColors_[colorIndex % chunkBackgroundColors_.size()];
-  QSettings settings;
   if (isDark()) {
     ret = QColor(ret.red() ^ 0xff, ret.green() ^ 0xff, ret.blue() ^ 0xff);
   }


### PR DESCRIPTION
Changes:
* `painter.drawText()` -> `painter.drawStaticText()` + text cache (20% speedup)
* Removed unused `QSettings settings;` in a frequently called function (6% speedup)
* Changed one `i`-based loop to foreach (1.5%)
* Many other small changes, each giving few percents.