### PR TITLE
Building instructions verfication using Docker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -389,6 +389,26 @@ builders['clang-format'] = { node ('ubuntu-16.04'){
   }
 }
 
+builders['building instructions - Docker'] = { node ('ubuntu-16.04') {
+    timestamps {
+      try {
+        stage('building instructions - Docker') {
+          checkout scm
+          sh """#!/bin/bash -ex
+            set -o pipefail
+            docker build -f test/build/Dockerfile .
+            docker ps -q -f status=exited | xargs --no-run-if-empty docker rm
+            docker images -q -f "dangling=true" | xargs --no-run-if-empty docker rmi
+          """
+        }
+      } catch (error) {
+        post_stage_failure(env.JOB_NAME, "building instructions - Docker", env.BUILD_ID,
+          env.BUILD_URL)
+        throw error
+      }
+    }
+  }
+}
 //parallel builders
 
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -389,7 +389,7 @@ builders['clang-format'] = { node ('ubuntu-16.04'){
   }
 }
 
-builders['building instructions - Docker'] = { node ('ubuntu-16.04') {
+builders['building instructions - Docker'] = { node ('docker-builder') {
     timestamps {
       try {
         stage('building instructions - Docker') {
@@ -397,8 +397,7 @@ builders['building instructions - Docker'] = { node ('ubuntu-16.04') {
           sh """#!/bin/bash -ex
             set -o pipefail
             docker build -f test/build/Dockerfile .
-            docker ps -q -f status=exited | xargs --no-run-if-empty docker rm
-            docker images -q -f "dangling=true" | xargs --no-run-if-empty docker rmi
+            docker system prune -f
           """
         }
       } catch (error) {

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Python tests dependencies:
 
 On Ubuntu it can be done like this::
 
-    apt-get install git python2.7 python3-pip
+    apt-get install git python2.7 python2.7-dev python3-pip
     pip3 install tox>=2.4.0
 
 On Windows if you want to avoid compiling OpenSSL everytime you clean build directory

--- a/test/build/Dockerfile
+++ b/test/build/Dockerfile
@@ -2,14 +2,24 @@ FROM ubuntu:16.04
 
 RUN apt-get update \
 	&& apt-get install -y \
-	cmake \
-	qtbase5-dev \
-	g++ \
-	python3 \
-	python3-virtualenv \
-	# python-virtualenv \
-	# python \
-	zlib1g-dev
+    cmake \
+    zlib1g-dev \
+    qtbase5-dev \
+    g++ \
+    python3 \
+    python3-venv \
+    python3-dev \
+    libffi-dev \
+    libssl-dev \
+    clang-tidy-3.9 \
+    clang-format-3.9 \
+    libclang-common-3.9-dev \
+    # python tests dependencies
+    git \
+    python2.7 \
+    python2.7-dev \
+    python3-pip \
+  && pip3 install tox>=2.4.0
 
 COPY . /veles
 
@@ -17,5 +27,8 @@ RUN mkdir /veles/build \
 	&& cd /veles/build \
 	&& cmake -D CMAKE_BUILD_TYPE=Debug .. \
 	&& cmake --build . -- -j5 \
-	&& cpack -D CPACK_PACKAGE_FILE_NAME=veles-docker -G ZIP -C Debug
+	&& cmake --build . --target lint -- -j5 \
+	&& cmake --build . --target format -- -j5 \
+	&& cpack -D CPACK_PACKAGE_FILE_NAME=veles-docker -G ZIP -C Debug \
+  && ( cd /veles/python && ./run_tests.sh )
 

--- a/test/build/Dockerfile
+++ b/test/build/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+
+RUN apt-get update \
+	&& apt-get install -y \
+	cmake \
+	qtbase5-dev \
+	g++ \
+	python3 \
+	python3-virtualenv \
+	# python-virtualenv \
+	# python \
+	zlib1g-dev
+
+COPY . /veles
+
+RUN mkdir /veles/build \
+	&& cd /veles/build \
+	&& cmake -D CMAKE_BUILD_TYPE=Debug .. \
+	&& cmake --build . -- -j5 \
+	&& cpack -D CPACK_PACKAGE_FILE_NAME=veles-docker -G ZIP -C Debug
+


### PR DESCRIPTION
Created Dockerfile for verification of building instructions on Ubuntu. You can run it:
`$ rm -rf build && sudo docker build -f test/build/Dockerfile .`

Created Jenkins target for verification on CI.

Fixed missing instructions.