### PR TITLE
Use -header-filter to specify headers

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,4 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*,google-*,performace-*'
+...
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,7 @@ if(CLANG_TIDY)
         COMMAND
             ${CLANG_TIDY}
             -checks=${LINT_CHECKS_STR}
+            -header-filter=${INCLUDE_DIR}
             ${LINT_SOURCE_FILE}
             --
             ${LINT_CXX_FLAGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,18 +497,16 @@ if(CLANG_TIDY)
   # to COMMAND, for example by using "-I$<JOIN:${LINT_INC_DIRS}, -I>"
   string(REPLACE ";" ";-I" LINT_INCLUDES "${LINT_INC_DIRS}")
 
-  # checks
-  list(APPEND LINT_CHECKS "google-*")
-  list(APPEND LINT_CHECKS "performance-*")
-
-  string(REPLACE ";" "," LINT_CHECKS_STR "${LINT_CHECKS}")
   message(STATUS "clang-tidy includes: -I${LINT_INCLUDES} -I${CMAKE_BINARY_DIR} -I${PROJECT_SOURCE_DIR}")
-  message(STATUS "clang-tidy checks: ${LINT_CHECKS_STR}")
   # parse CMAKE_CXX_FLAGS to list, so spaces will not be escaped in COMMANDs
   separate_arguments(LINT_CXX_FLAGS UNIX_COMMAND ${CMAKE_CXX_FLAGS})
 
-  # as an alternative - we could use
-  # set(CMAKE_CXX_CLANG_TIDY clang-tidy;-style=google;-checks=${LINT_CHECKS_STR}")
+  # as an alternative - we could use:
+  ### list(APPEND LINT_CHECKS "google-*")
+  ### list(APPEND LINT_CHECKS "performance-*")
+  ### string(REPLACE ";" "," LINT_CHECKS_STR "${LINT_CHECKS}")
+  ### set(CMAKE_CXX_CLANG_TIDY clang-tidy;-style=google;-checks=${LINT_CHECKS_STR}")
+  #
   # and then all the magic should happen at compile time
   # cmake 3.6+ required (Ubuntu 18.04 LTS)
   add_custom_target(lint)
@@ -533,7 +531,6 @@ if(CLANG_TIDY)
         ${LINT_TARGET_NAME}
         COMMAND
             ${CLANG_TIDY}
-            -checks=${LINT_CHECKS_STR}
             -header-filter=${INCLUDE_DIR}
             ${LINT_SOURCE_FILE}
             --

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ corresponding to the dependencies above.
 
 On Ubuntu it can be done like this::
 
-    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev clang-tidy-3.9 clang-format-3.9 libclang-common-3.9-dev
+    apt-get install cmake zlib1g-dev qtbase5-dev g++ python3 python3-venv python3-dev libffi-dev libssl-dev clang-tidy-4.0 clang-format-4.0 libclang-common-4.0-dev
 
 To build ::
 


### PR DESCRIPTION
Specifying -header-filter makes clang-tidy report errors also in header files.

Moved clang-tidy config to .clang-tidy file