### PR TITLE
Fix networking

### DIFF
--- a/python/veles/util/helpers.py
+++ b/python/veles/util/helpers.py
@@ -51,6 +51,10 @@ def get_logging_argparse():
     return parser
 
 
+Url = collections.namedtuple('Url', ['scheme', 'auth_key', 'fingerprint',
+                                     'host', 'port', 'path'])
+
+
 def parse_url(url):
     scheme, url = url.split('://', 1)
     scheme = UrlScheme(scheme.lower())
@@ -68,8 +72,6 @@ def parse_url(url):
         path = None
         host, _, port = loc.rpartition(':')
         port = int(port)
-    Url = collections.namedtuple(
-        'URL', ['scheme', 'auth_key', 'fingerprint', 'host', 'port', 'path'])
     return Url(scheme, auth_key, fingerprint, host, port, path)
 
 


### PR DESCRIPTION
Fixes #316.

* Fixes certificate error on macOS (#316)
* Disallows valid SSL certificates with non-matching fingerprint
* Fixes a random unrelated issue in Python code (I'm too lazy to do a separate PR from this, sorry :P )

I have much more changes for networking code locally, but let's merge this fix for now.