### PR TITLE
Add contact info irc

### DIFF
--- a/src/ui/veles_mainwindow.cc
+++ b/src/ui/veles_mainwindow.cc
@@ -95,6 +95,7 @@ void VelesMainWindow::about() {
                         "Version: %1\n"
                         "\n"
                         "Report bugs to contact@veles.io\n"
+                        "IRC: #veles@freenode.net\n"
                         "https://veles.io/\n"
                         "\n"
                         "Copyright 2017 CodiLime\n"


### PR DESCRIPTION
I added info about irc like @koriakin proposed in #351 between email and website address. 

![veles_about](https://user-images.githubusercontent.com/13544213/30929941-61825ba0-a3c0-11e7-938c-ce46708bd57a.png)
