### PR TITLE
Waiting until local server exits

### DIFF
--- a/src/ui/connectionmanager.cc
+++ b/src/ui/connectionmanager.cc
@@ -256,6 +256,7 @@ void ConnectionManager::killLocalServer() {
 #else
     server_process_->terminate();
 #endif
+    server_process_->waitForFinished(1000);
   }
 }
 


### PR DESCRIPTION
Waiting for a while avoids `QProcess: Destroyed while process ("python3") is still running.` error message.