### PR TITLE
Fix fixed-width fonts

### DIFF
--- a/include/util/settings/theme.h
+++ b/include/util/settings/theme.h
@@ -38,6 +38,7 @@ QColor chunkBackground(int color_index);
 QColor editedBackground();
 QColor byteColor(uint8_t byte);
 QFont font();
+QFont fixedFont();
 
 }  // namespace theme
 }  // namespace settings

--- a/src/ui/fileblobmodel.cc
+++ b/src/ui/fileblobmodel.cc
@@ -19,10 +19,10 @@
 #include <QColor>
 #include <QFont>
 #include <QSize>
+
 #include "dbif/method.h"
 #include "dbif/types.h"
 #include "dbif/universe.h"
-
 #include "ui/rootfileblobitem.h"
 #include "util/settings/theme.h"
 
@@ -228,11 +228,7 @@ QVariant FileBlobModel::positionColumnData(FileBlobItem* item, int role) const {
     return zeroPaddedHexNumber(begin) + ":" + zeroPaddedHexNumber(end);
   }
   if (role == Qt::FontRole) {
-#ifdef Q_OS_WIN32
-    return QFont("Courier", 10);
-#else
-    return QFont("Monospace", 10);
-#endif
+    return util::settings::theme::fixedFont();
   }
   if (role == ROLE_BEGIN) {
     return QString::number(begin);

--- a/src/ui/hexedit.cc
+++ b/src/ui/hexedit.cc
@@ -132,8 +132,7 @@ HexEdit::HexEdit(FileBlobModel* dataModel, QItemSelectionModel* selectionModel,
       cursor_visible_(false),
       in_insert_mode_(false),
       edit_engine_(dataModel_) {
-  auto font = util::settings::theme::font();
-  setFont(font);
+  setFont(util::settings::theme::fixedFont());
 
   connect(dataModel_, &FileBlobModel::newBinData, this, &HexEdit::newBinData);
   connect(dataModel_, &FileBlobModel::dataChanged, this, &HexEdit::dataChanged);

--- a/src/ui/hexeditwidget.cc
+++ b/src/ui/hexeditwidget.cc
@@ -308,7 +308,7 @@ void HexEditWidget::createSelectionInfo() {
 
   layout->addWidget(change_edit_mode_button_);
   selection_label_ = new QLabel;
-  selection_label_->setFont(util::settings::theme::font());
+  selection_label_->setFont(util::settings::theme::fixedFont());
   selection_label_->setText("");
   selection_label_->setTextInteractionFlags(Qt::TextSelectableByMouse |
                                             Qt::TextSelectableByKeyboard);

--- a/src/util/settings/theme.cc
+++ b/src/util/settings/theme.cc
@@ -119,9 +119,14 @@ QColor byteColor(uint8_t byte) {
   return colorInvertedIfDark(QColor(red, green, blue));
 }
 
-QFont font() {
-#ifdef Q_OS_WIN32
+QFont font() { return QFont{}; }
+
+QFont fixedFont() {
+#if defined(Q_OS_WIN32)
   return QFont("Courier", 10);
+#elif defined(Q_OS_MAC)
+  // For some reason font with size=10 looks too small on macOS.
+  return QFont("Monaco", 12);
 #else
   return QFont("Monospace", 10);
 #endif


### PR DESCRIPTION
This fixes the font interface and also makes hexeditor on macOS use fixed-width fonts.
Fixes #339.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/codilime/veles/420)
<!-- Reviewable:end -->
